### PR TITLE
PDF internal links enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Customize the behavior of Obsidian\'s built-in right-click menu in PDF view.
 
 ### Misc
 
+- **Enable history navigation for PDF internal links**: When enabled, clicking the "navigate back" (left arrow) button will take you back to the page you were originally viewing before clicking on an internal link in the PDF file.
 - **Render markdown in sticky notes**
 
 ## CSS customization

--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ These features make Obsidian a unique PDF annotation tool that tightly connects 
 - **Hover sync (PDF viewer → Backlinks pane)**: Hovering over highlighted text or annotation will also highlight the corresponding item in the [backlink pane](https://help.obsidian.md/Plugins/Backlinks).
 - **Hover sync (Backlinks pane → PDF viewer)**: In the backlinks pane, hover your mouse over an backlink item to highlight the corresponding text or annotation in the PDF viewer.
 
+### PDF internal links enhancement
+
+Make it easier to work with internal links embedded in PDF files.
+
+- **Hover+command/ctrl to show a popover preview of PDF internal links**: See [below](#css-customization) for advanced CSS customization.
+- **Enable history navigation for PDF internal links**: When enabled, clicking the "navigate back" (left arrow) button will take you back to the page you were originally viewing before clicking on an internal link in the PDF file.
+
 ### Opening links to PDF files
 
 #### Open PDF links cleverly
@@ -166,12 +173,13 @@ Customize the behavior of Obsidian\'s built-in right-click menu in PDF view.
 
 ### Misc
 
-- **Enable history navigation for PDF internal links**: When enabled, clicking the "navigate back" (left arrow) button will take you back to the page you were originally viewing before clicking on an internal link in the PDF file.
 - **Render markdown in sticky notes**
 
 ## CSS customization
 
-You can customize the styling of highlighted text using [CSS snippets](https://help.obsidian.md/Extending+Obsidian/CSS+snippets).
+You can customize the styling of various components of PDF++ using [CSS snippets](https://help.obsidian.md/Extending+Obsidian/CSS+snippets).
+
+### Text highlights
 
 Here is a list of CSS selectors to target:
 
@@ -180,6 +188,31 @@ Here is a list of CSS selectors to target:
 - `.pdf-plus-backlink-highlight-layer .pdf-plus-backlink`: PDF text highlights that PDF++ generates from backlinks
   - Use `.pdf-plus-backlink-highlight-layer .pdf-plus-backlink[data-highlight-color="<COLOR NAME>"]` to target a specific color
 - `.pdf-plus-backlink-highlight-layer .pdf-plus-backlink.hovered-highlight`: PDF text highlights that PDF++ generates when you hover over an item in the backlinks pane
+
+### Popover preview of PDF internal links
+
+Sometimes, You may find preview popovers too tall.
+
+For example, suppose you're reading a LaTeX-generated paper.
+You can hover over an inline citation (e.g. "Author et al., 2024") to show a popover preview of the corresponding entry in the bibliography section.
+Since a bib entry is not that tall, the popover often has too much vertical space.
+
+Now, use the following CSS snippet to remove the extra space:
+
+```css
+.pdf-plus-pdf-internal-link-popover[data-dest^="cite."] {
+    height: 200px !important;
+}
+```
+
+The `data-dest` attribute is the ID of the named destination (i.e. link target) that the internal link points to, which starts with `cite.` for bibliographic items.
+In general, you can get the ID by the following steps:
+- Press `command`+`option`+`I` (macOS) / `Ctrl`+`Shift`+`I` (windows) to open the developer tool.
+- Click the arrow icon at the top-left corner of the dev tool to enter the inspection mode.
+- Click the PDF internal link that you want to inspect. Then, an `<a>` element will be highlighted in the "Elements" tab of the dev tool.
+- The `href` attribute of the `<a>` element is the destination ID with a hash sign (`#`) prepended.
+
+You can also find a [great tutorial](https://forum.obsidian.md/t/getting-comfortable-with-obsidian-css/133) on the forum.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ These features make Obsidian a unique PDF annotation tool that tightly connects 
 
 Make it easier to work with internal links embedded in PDF files.
 
-- **Hover+command/ctrl to show a popover preview of PDF internal links**: See [below](#css-customization) for advanced CSS customization.
+- **Show a popover preview of PDF internal links by hover+command/ctrl**: See [below](#css-customization) for advanced CSS customization.
 - **Enable history navigation for PDF internal links**: When enabled, clicking the "navigate back" (left arrow) button will take you back to the page you were originally viewing before clicking on an internal link in the PDF file.
 
 ### Opening links to PDF files

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,7 @@ import { DomManager } from 'dom-manager';
 import { DEFAULT_SETTINGS, PDFPlusSettings, PDFPlusSettingTab } from 'settings';
 import { copyLink, destIdToSubpath, getToolbarAssociatedWithSelection, iterateBacklinkViews, iteratePDFViews, subpathToParams } from 'utils';
 import { PDFEmbed, PDFView, PDFViewerChild } from 'typings';
+import { PDFInternalLinkHoverParent } from 'pdf-internal-links';
 
 
 export default class PDFPlus extends Plugin {
@@ -287,8 +288,7 @@ export default class PDFPlus extends Plugin {
 							this.app.workspace.trigger('hover-link', {
 								event,
 								source: 'pdf-plus',
-								// @ts-ignore
-								hoverParent: view,
+								hoverParent: new PDFInternalLinkHoverParent(this, destId),
 								targetEl,
 								linktext
 							});
@@ -396,5 +396,9 @@ export default class PDFPlus extends Plugin {
 			return viewer.getPageView(viewer.currentPageNumber - 1);
 		}
 		return null;
+	}
+
+	getPDFDocument(activeOnly: boolean = false) {
+		return this.getRawPDFViewer(activeOnly)?.pdfDocument;
 	}
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,11 +5,11 @@ import { patchBacklink } from 'patchers/backlink';
 import { patchWorkspace } from 'patchers/workspace';
 import { patchPagePreview } from 'patchers/page-preview';
 import { SelectToCopyMode } from 'select-to-copy';
+import { ColorPalette } from 'color-palette';
 import { DomManager } from 'dom-manager';
 import { DEFAULT_SETTINGS, PDFPlusSettings, PDFPlusSettingTab } from 'settings';
-import { copyLink, getToolbarAssociatedWithSelection, iterateBacklinkViews, iteratePDFViews, subpathToParams } from 'utils';
+import { copyLink, destIdToSubpath, getToolbarAssociatedWithSelection, iterateBacklinkViews, iteratePDFViews, subpathToParams } from 'utils';
 import { PDFEmbed, PDFView, PDFViewerChild } from 'typings';
-import { ColorPalette } from 'color-palette';
 
 
 export default class PDFPlus extends Plugin {
@@ -38,7 +38,6 @@ export default class PDFPlus extends Plugin {
 		this.addSettingTab(new PDFPlusSettingTab(this));
 
 		this.domManager = this.addChild(new DomManager(this));
-		// this.app.workspace.onLayoutReady(() => this.loadStyle());
 
 		this.selectToCopyMode = this.addChild(new SelectToCopyMode(this));
 		this.selectToCopyMode.unload(); // disabled by default
@@ -56,47 +55,9 @@ export default class PDFPlus extends Plugin {
 
 		this.registerGlobalVariables();
 
-		// Make PDF embeds with a subpath unscrollable
-		this.registerGlobalDomEvent('wheel', (evt) => {
-			if (this.settings.embedUnscrollable
-				&& evt.target instanceof HTMLElement
-				&& evt.target.closest('.pdf-embed[src*="#"] .pdf-viewer-container')) {
-				evt.preventDefault();
-			}
-		}, { passive: false });
+		this.registerGlobalDomEvents();
 
-		// Double-lick PDF embeds to open links
-		this.registerGlobalDomEvent('dblclick', (evt) => {
-			if (this.settings.dblclickEmbedToOpenLink && evt.target instanceof HTMLElement) {
-				// .pdf-container is necessary to avoid opening links when double-clicking on the toolbar
-				const linktext = evt.target.closest('.pdf-embed[src] > .pdf-container')?.parentElement!.getAttribute('src');
-				if (linktext) {
-					const viewerEl = evt.target.closest<HTMLElement>('div.pdf-viewer');
-					const sourcePath = viewerEl ? (this.pdfViwerChildren.get(viewerEl)?.file?.path ?? '') : '';
-					this.app.workspace.openLinkText(linktext, sourcePath, Keymap.isModEvent(evt));
-					evt.preventDefault();
-				}
-			}
-		})
-
-		// keep this.pdfViewerChildren up-to-date
-		this.registerEvent(this.app.workspace.on('layout-change', () => {
-			for (const viewerEl of this.pdfViwerChildren.keys()) {
-				if (!viewerEl?.isShown()) this.pdfViwerChildren.delete(viewerEl);
-			}
-		}));
-
-		if (Platform.isDesktopApp) {
-			this.registerEvent(this.app.workspace.on('active-leaf-change', (leaf) => {
-				if (this.settings.syncWithDefaultApp && leaf && leaf.view instanceof EditableFileView && leaf.view.file?.extension === 'pdf') {
-					const file = leaf.view.file;
-					this.app.openWithDefaultApp(file.path);
-					if (this.settings.focusObsidianAfterOpenPDFWithDefaultApp) {
-						open('obsidian://'); // move focus back to Obsidian
-					}
-				}
-			}));	
-		}
+		this.registerEvents();
 	}
 
 	checkVersion() {
@@ -258,6 +219,106 @@ export default class PDFPlus extends Plugin {
 		this.registerEvent(this.app.workspace.on('window-open', (win, window) => {
 			this.registerDomEvent(window.document, type, callback, options);
 		}));
+	}
+
+	registerGlobalDomEvents() {
+		this.enhancePDFInternalLinks();
+
+		// Make PDF embeds with a subpath unscrollable
+		this.registerGlobalDomEvent('wheel', (evt) => {
+			if (this.settings.embedUnscrollable
+				&& evt.target instanceof HTMLElement
+				&& evt.target.closest('.pdf-embed[src*="#"] .pdf-viewer-container')) {
+				evt.preventDefault();
+			}
+		}, { passive: false });
+
+		// Double-lick PDF embeds to open links
+		this.registerGlobalDomEvent('dblclick', (evt) => {
+			if (this.settings.dblclickEmbedToOpenLink && evt.target instanceof HTMLElement) {
+				// .pdf-container is necessary to avoid opening links when double-clicking on the toolbar
+				const linktext = evt.target.closest('.pdf-embed[src] > .pdf-container')?.parentElement!.getAttribute('src');
+				if (linktext) {
+					const viewerEl = evt.target.closest<HTMLElement>('div.pdf-viewer');
+					const sourcePath = viewerEl ? (this.pdfViwerChildren.get(viewerEl)?.file?.path ?? '') : '';
+					this.app.workspace.openLinkText(linktext, sourcePath, Keymap.isModEvent(evt));
+					evt.preventDefault();
+				}
+			}
+		});
+	}
+
+	enhancePDFInternalLinks() {
+		// record history when clicking an internal link IN a PDF file
+		this.registerGlobalDomEvent('click', (evt) => {
+			if (this.settings.recordPDFInternalLinkHistory
+				&& evt.target instanceof HTMLElement
+				&& evt.target.closest('section.linkAnnotation[data-internal-link]')) {
+				const targetEl = evt.target;
+				this.app.workspace.iterateAllLeaves((leaf) => {
+					if (leaf.view.getViewType() === 'pdf' && leaf.containerEl.contains(targetEl)) {
+						leaf.recordHistory(leaf.getHistoryState());
+					}
+				});
+			}
+		});
+
+		// Hover+Mod to show popover preview of PDF internal links
+		this.registerGlobalDomEvent('mouseover', (event) => {
+			if (this.settings.enableHoverPDFInternalLink
+				&& event.target instanceof HTMLElement
+				&& event.target.matches('section.linkAnnotation[data-internal-link] > a[href^="#"]')) {
+				const targetEl = event.target as HTMLAnchorElement;
+				const destId = targetEl.getAttribute('href')!.slice(1);
+
+				this.app.workspace.iterateAllLeaves((leaf) => {
+					if (leaf.view.getViewType() === 'pdf' && leaf.containerEl.contains(targetEl)) {
+						const view = leaf.view as PDFView;
+						if (!view.file) return;
+
+						view.viewer.then(async (child) => {
+							const doc = child.pdfViewer.pdfViewer?.pdfDocument;
+							if (!doc) return;
+
+							const subpath = await destIdToSubpath(destId, doc);
+							if (subpath === null) return;
+							const linktext = view.file!.path + subpath;
+
+							this.app.workspace.trigger('hover-link', {
+								event,
+								source: 'pdf-plus',
+								// @ts-ignore
+								hoverParent: view,
+								targetEl,
+								linktext
+							});
+						});
+					}
+				});
+			}
+		});
+	}
+
+	registerEvents() {
+		// keep this.pdfViewerChildren up-to-date
+		this.registerEvent(this.app.workspace.on('layout-change', () => {
+			for (const viewerEl of this.pdfViwerChildren.keys()) {
+				if (!viewerEl?.isShown()) this.pdfViwerChildren.delete(viewerEl);
+			}
+		}));
+
+		// Sync the external app with Obsidian
+		if (Platform.isDesktopApp) {
+			this.registerEvent(this.app.workspace.on('active-leaf-change', (leaf) => {
+				if (this.settings.syncWithDefaultApp && leaf && leaf.view instanceof EditableFileView && leaf.view.file?.extension === 'pdf') {
+					const file = leaf.view.file;
+					this.app.openWithDefaultApp(file.path);
+					if (this.settings.focusObsidianAfterOpenPDFWithDefaultApp) {
+						open('obsidian://'); // move focus back to Obsidian
+					}
+				}
+			}));
+		}
 	}
 
 	copyLinkToSelection(checking: boolean) {

--- a/src/patchers/pdf.ts
+++ b/src/patchers/pdf.ts
@@ -20,6 +20,7 @@ export const patchPDF = (plugin: PDFPlus): boolean => {
     const toolbar = child.toolbar;
     if (!toolbar) return false;
 
+    // TODO: Add color palette state handling to getState/setState
     plugin.register(around(pdfView.constructor.prototype, {
         getState(old) {
             return function () {
@@ -39,7 +40,13 @@ export const patchPDF = (plugin: PDFPlus): boolean => {
                         const self = this as PDFView;
                         const pdfViewer = self.viewer.child?.pdfViewer.pdfViewer;
                         if (pdfViewer) {
-                            pdfViewer.currentPageNumber = state.page;
+                            if (pdfViewer.pagesCount) { // pages are already loaded
+                                pdfViewer.currentPageNumber = state.page;
+                            } else { // pages are not loaded yet (this is the case typically when opening a different file)
+                                registerPDFEvent('pagesloaded', pdfViewer.eventBus, null, () => {
+                                    pdfViewer.currentPageNumber = state.page;
+                                });
+                            }
                         }
                     }
                 });

--- a/src/pdf-internal-links.ts
+++ b/src/pdf-internal-links.ts
@@ -1,0 +1,25 @@
+import { HoverParent, HoverPopover } from 'obsidian';
+
+import PDFPlus from 'main';
+
+
+export class PDFInternalLinkHoverParent implements HoverParent {
+    _hoverPopover: HoverPopover | null
+
+    constructor(public plugin: PDFPlus, public destId: string) {
+        this._hoverPopover = null;
+    }
+
+    get hoverPopover() {
+        return this._hoverPopover;
+    }
+
+    set hoverPopover(hoverPopover) {
+        this._hoverPopover = hoverPopover;
+        if (hoverPopover) {
+            const el = hoverPopover.hoverEl;
+            el.addClass('pdf-plus-pdf-internal-link-popover');
+            el.dataset.dest = this.destId;
+        }
+    }
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -687,8 +687,10 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 		this.addToggleSetting('recordPDFInternalLinkHistory')
 			.setName('Enable history navigation for PDF internal links')
 			.setDesc('When enabled, clicking the "navigate back" (left arrow) button will take you back to the page you were originally viewing before clicking on an internal link in the PDF file.');
+		// @ts-ignore
+		const noModKey = this.app.internalPlugins.plugins['page-preview'].instance.overrides['pdf-plus'] === false;
 		this.addToggleSetting('enableHoverPDFInternalLink', () => this.redisplay())
-			.setName(`Hover+${getModifierNameInPlatform('Mod').toLowerCase()} to show a popover preview of PDF internal links`);
+			.setName(`Show a popover preview of PDF internal links by hover${noModKey ? '' : ('+' + getModifierNameInPlatform('Mod').toLowerCase())}`);
 
 
 		this.addHeading('Opening links to PDF files');

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -82,6 +82,8 @@ export interface PDFPlusSettings {
 	hoverPDFLinkToOpen: boolean;
 	ignoreHeightParamInPopoverPreview: boolean;
 	filterBacklinksByPageDefault: boolean;
+	enableHoverPDFInternalLink: boolean;
+	recordPDFInternalLinkHistory: boolean;
 	renderMarkdownInStickyNote: boolean;
 }
 
@@ -169,6 +171,8 @@ export const DEFAULT_SETTINGS: PDFPlusSettings = {
 	hoverPDFLinkToOpen: false,
 	ignoreHeightParamInPopoverPreview: true,
 	filterBacklinksByPageDefault: true,
+	enableHoverPDFInternalLink: true,
+	recordPDFInternalLinkHistory: true,
 	renderMarkdownInStickyNote: true,
 };
 
@@ -662,6 +666,15 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 				.setName('Highlight color for hover sync (Backlinks pane → PDF viewer)')
 				.setDesc('To add a new color, click the "+" button in the "highlight colors" setting above.');
 		}
+
+
+		this.addHeading('PDF internal links enhancement')
+			.setDesc('Make it easier to work with internal links embedded in PDF files.');
+		this.addToggleSetting('enableHoverPDFInternalLink')
+			.setName(`Hover+${getModifierNameInPlatform('Mod').toLowerCase()} to show popover preview of PDF internal links`)
+		this.addToggleSetting('recordPDFInternalLinkHistory')
+			.setName('Enable history navigation for PDF internal links')
+			.setDesc('When enabled, clicking the "navigate back" (left arrow) button will take you back to the page you were originally viewing before clicking on an internal link in the PDF file.')
 
 
 		this.addHeading('Opening links to PDF files');

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -218,6 +218,20 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 			});
 	}
 
+	addTextAreaSetting(settingName: KeysOfType<PDFPlusSettings, string>, placeholder?: string, onBlur?: () => any) {
+		return this.addSetting(settingName)
+			.addTextArea((text) => {
+				text.setValue(this.plugin.settings[settingName])
+					.setPlaceholder(placeholder ?? '')
+					.onChange(async (value) => {
+						// @ts-ignore
+						this.plugin.settings[settingName] = value;
+						await this.plugin.saveSettings();
+					});
+				if (onBlur) this.component.registerDomEvent(text.inputEl, 'blur', onBlur);
+			});
+	}
+
 	addNumberSetting(settingName: KeysOfType<PDFPlusSettings, number>) {
 		return this.addSetting(settingName)
 			.addText((text) => {
@@ -670,11 +684,11 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 
 		this.addHeading('PDF internal links enhancement')
 			.setDesc('Make it easier to work with internal links embedded in PDF files.');
-		this.addToggleSetting('enableHoverPDFInternalLink')
-			.setName(`Hover+${getModifierNameInPlatform('Mod').toLowerCase()} to show popover preview of PDF internal links`)
 		this.addToggleSetting('recordPDFInternalLinkHistory')
 			.setName('Enable history navigation for PDF internal links')
-			.setDesc('When enabled, clicking the "navigate back" (left arrow) button will take you back to the page you were originally viewing before clicking on an internal link in the PDF file.')
+			.setDesc('When enabled, clicking the "navigate back" (left arrow) button will take you back to the page you were originally viewing before clicking on an internal link in the PDF file.');
+		this.addToggleSetting('enableHoverPDFInternalLink', () => this.redisplay())
+			.setName(`Hover+${getModifierNameInPlatform('Mod').toLowerCase()} to show a popover preview of PDF internal links`);
 
 
 		this.addHeading('Opening links to PDF files');

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -136,12 +136,14 @@ interface PDFToolbar {
 interface RawPDFViewer {
     pdfDocument: PDFDocumentProxy;
     pagesPromise: Promise<any> | null;
+    pagesCount: number;
     /** 1-based page number. This is an accessor property; the setter can be used to scroll to a page and dispatches 'pagechanging' event */
     currentPageNumber: number;
     _pages: PDFPageView[];
     /** Accessor property. 0 for "single page", 1 for "two page (odd)", 2 for "two page (even)" */
     spreadMode: number;
     viewer: HTMLElement; // div.pdf-viewer
+    eventBus: EventBus;
     getPageView(page: number): PDFPageView;
 }
 
@@ -487,6 +489,13 @@ interface EmbedRegistry {
     getEmbedCreator(file: TFile): EmbedCreator | null;
 }
 
+interface HistoryState {
+    title: string;
+    icon: string;
+    state: any;
+    eState: any;
+}
+
 declare module 'obsidian' {
     interface App {
         setting: AppSetting;
@@ -523,6 +532,16 @@ declare module 'obsidian' {
 
     interface Workspace {
         getActiveFileView(): FileView | null;
+        trigger(name: string, ...data: any[]): void;
+        trigger(name: 'hover-link', ctx: {
+            event: MouseEvent;
+            source: string;
+            hoverParent: HoverParent;
+            targetEl?: HTMLElement;
+            linktext: string;
+            sourcePath?: string;
+            state?: any;
+        }): void;
     }
 
     interface WorkspaceLeaf {
@@ -533,6 +552,8 @@ declare module 'obsidian' {
         highlight(): void;
         unhighlight(): void;
         isVisible(): boolean;
+        getHistoryState(): HistoryState,
+        recordHistory(historyState: HistoryState): void;
     }
 
     interface WorkspaceTabs {

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -142,7 +142,14 @@ interface RawPDFViewer {
     _pages: PDFPageView[];
     /** Accessor property. 0 for "single page", 1 for "two page (odd)", 2 for "two page (even)" */
     spreadMode: number;
+    scroll: {
+        right: boolean;
+        down: boolean;
+        lastX: number;
+        lastY: number;
+    };
     viewer: HTMLElement; // div.pdf-viewer
+    container: HTMLElement; // div.pdf-viewer-container
     eventBus: EventBus;
     getPageView(page: number): PDFPageView;
 }


### PR DESCRIPTION
Make it easier to work with internal links embedded in PDF files.

- **Hover+command/ctrl to show a popover preview of PDF internal links**
- **Enable history navigation for PDF internal links**: When enabled, clicking the "navigate back" (left arrow) button will take you back to the page you were originally viewing before clicking on an internal link in the PDF file.
