### PR TITLE
add toggle for rectangular selection embed vs nonembed

### DIFF
--- a/src/context-menu.ts
+++ b/src/context-menu.ts
@@ -623,7 +623,7 @@ export class PDFPlusContextMenu extends PDFPlusMenu {
                                         if (!display && annot.data.rect) {
                                             display = child.getTextByRect(pageView, annot.data.rect);
                                         }
-                                        const link = lib.generateMarkdownLink(file, '', subpath, display ?? undefined).slice(1);
+                                        const link = lib.generateMarkdownLink(file, '', subpath, display ?? undefined);
                                         // How does the electron version differ?
                                         navigator.clipboard.writeText(link);
                                         plugin.lastCopiedDestInfo = { file, destName: destId };

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -333,7 +333,7 @@ export class PDFPlusCommands extends PDFPlusLibSubmodule {
                 destArray = [state.page - 1, 'XYZ', state.left, state.top, state.zoom ?? 0];
             }
             const display = view.viewer.child?.getPageLinkAlias(state.page);
-            const link = this.lib.generateMarkdownLink(view.file, '', subpath, display).slice(1);
+            const link = this.lib.generateMarkdownLink(view.file, '', subpath, display);
             navigator.clipboard.writeText(link);
             new Notice(`${this.plugin.manifest.name}: Link copied to clipboard`);
 

--- a/src/lib/copy-link.ts
+++ b/src/lib/copy-link.ts
@@ -95,20 +95,20 @@ export class copyLinkLib extends PDFPlusLibSubmodule {
 
     getLinkTemplateVariables(child: PDFViewerChild, displayTextFormat: string | undefined, file: TFile, subpath: string, page: number, text: string, comment: string, sourcePath?: string) {
         sourcePath = sourcePath ?? '';
-        const link = this.app.fileManager.generateMarkdownLink(file, sourcePath, subpath).slice(1);
+        const link = this.app.fileManager.generateMarkdownLink(file, sourcePath, subpath) ;
         let linktext = this.app.metadataCache.fileToLinktext(file, sourcePath) + subpath;
         if (this.app.vault.getConfig('useMarkdownLinks')) {
             linktext = encodeLinktext(linktext);
         }
         const display = this.getDisplayText(child, displayTextFormat, file, page, text, comment);
         // https://github.com/obsidianmd/obsidian-api/issues/154
-        // const linkWithDisplay = app.fileManager.generateMarkdownLink(file, sourcePath, subpath, display).slice(1);
-        const linkWithDisplay = this.lib.generateMarkdownLink(file, sourcePath, subpath, display || undefined).slice(1);
+        // const linkWithDisplay = app.fileManager.generateMarkdownLink(file, sourcePath, subpath, display) ;
+        const linkWithDisplay = this.lib.generateMarkdownLink(file, sourcePath, subpath, display || undefined) ;
 
-        const linkToPage = this.app.fileManager.generateMarkdownLink(file, sourcePath, `#page=${page}`).slice(1);
+        const linkToPage = this.app.fileManager.generateMarkdownLink(file, sourcePath, `#page=${page}`) ;
         // https://github.com/obsidianmd/obsidian-api/issues/154
-        // const linkToPageWithDisplay = app.fileManager.generateMarkdownLink(file, sourcePath, `#page=${page}`, display).slice(1);
-        const linkToPageWithDisplay = this.lib.generateMarkdownLink(file, sourcePath, `#page=${page}`, display || undefined).slice(1);
+        // const linkToPageWithDisplay = app.fileManager.generateMarkdownLink(file, sourcePath, `#page=${page}`, display) ;
+        const linkToPageWithDisplay = this.lib.generateMarkdownLink(file, sourcePath, `#page=${page}`, display || undefined) ;
 
         return {
             link,
@@ -417,14 +417,17 @@ export class copyLinkLib extends PDFPlusLibSubmodule {
             const display = this.getDisplayText(child, undefined, file, pageNumber, '');
             let subpath = `#page=${pageNumber}&rect=${rect.map((num) => Math.round(num)).join(',')}`;
             if (colorName) subpath += `&color=${colorName}`;
-            const embedLink = this.lib.generateMarkdownLink(file, sourcePath ?? '', subpath, display);
+            const nonembedLink = this.lib.generateMarkdownLink(file, sourcePath ?? '', subpath, display);
 
             (async () => {
-                let text = embedLink;
+                let text =nonembedLink;
                 const page = child.getPage(pageNumber).pdfPage;
                 const extension = this.settings.rectImageExtension;
-
-                if (!this.settings.rectEmbedStaticImage) {
+                if (!this.settings.rectEmbed) {
+                    await navigator.clipboard.writeText(text);
+                    this.onCopyFinish(text);
+                } else if (!this.settings.rectEmbedStaticImage) {
+                    text = "!" + nonembedLink;
                     await navigator.clipboard.writeText(text);
 
                     this.onCopyFinish(text);
@@ -432,7 +435,7 @@ export class copyLinkLib extends PDFPlusLibSubmodule {
                     const imagePath = await this.app.fileManager.getAvailablePathForAttachment(file.basename + '.' + extension, '');
                     const useWikilinks = !this.app.vault.getConfig('useMarkdownLinks');
                     const imageEmbedLink = useWikilinks ? `![[${imagePath}]]` : `![](${encodeLinktext(imagePath)})`;
-                    text = imageEmbedLink + '\n\n' + embedLink.slice(1);
+                    text = imageEmbedLink + '\n\n' + nonembedLink ;
 
                     await navigator.clipboard.writeText(text);
 
@@ -449,7 +452,7 @@ export class copyLinkLib extends PDFPlusLibSubmodule {
                 } else {
                     const dataUrl = await this.lib.pdfPageToImageDataUrl(page, { type: `image/${extension}`, cropRect: rect });
                     const imageEmbedLink = `![](${dataUrl})`;
-                    text = imageEmbedLink + '\n\n' + embedLink.slice(1);
+                    text = imageEmbedLink + '\n\n' + nonembedLink ;
 
                     await navigator.clipboard.writeText(text);
 
@@ -474,7 +477,7 @@ export class copyLinkLib extends PDFPlusLibSubmodule {
 
         if (!checking) {
             const display = this.lib.copyLink.getDisplayText(child, undefined, file, pageNumber, query);
-            const link = this.lib.generateMarkdownLink(file, '', `#search=${query}`, display).slice(1);
+            const link = this.lib.generateMarkdownLink(file, '', `#search=${query}`, display) ;
 
             (async () => {
                 await navigator.clipboard.writeText(link);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -476,7 +476,7 @@ export class PDFPlusLib {
                 : '[['.concat(linktext, ']]');
         }
 
-        return 'md' !== file.extension ? '!' + nonEmbedLink : nonEmbedLink;
+        return nonEmbedLink;
     }
 
     getBacklinkIndexForFile(file: TFile) {

--- a/src/patchers/pdf-internals.ts
+++ b/src/patchers/pdf-internals.ts
@@ -570,7 +570,7 @@ const patchPDFViewerChild = (plugin: PDFPlus, child: PDFViewerChild) => {
         getMarkdownLink(old) {
             return function (this: PDFViewerChild, subpath?: string, alias?: string, embed?: boolean): string {
                 if (!this.file) return old.call(this, subpath, alias, embed);
-                const embedLink = lib.generateMarkdownLink(this.file, '', subpath, alias);
+                const embedLink = /*"!" +*/ lib.generateMarkdownLink(this.file, '', subpath, alias); //comment added to reflect a change in the function used
                 if (embed) return embedLink;
                 return embedLink.slice(1);
             }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -240,6 +240,7 @@ export interface PDFPlusSettings {
 	newFileTemplatePath: string;
 	newPDFLocation: NewFileLocation;
 	newPDFFolderPath: string;
+	rectEmbed: boolean;
 	rectEmbedStaticImage: boolean;
 	rectImageFormat: 'file' | 'data-url';
 	rectImageExtension: ImageExtension;
@@ -514,6 +515,7 @@ export const DEFAULT_SETTINGS: PDFPlusSettings = {
 	newFileTemplatePath: '',
 	newPDFLocation: 'current',
 	newPDFFolderPath: '',
+	rectEmbed: true,
 	rectEmbedStaticImage: false,
 	rectImageFormat: 'file',
 	rectImageExtension: 'webp',
@@ -1656,22 +1658,29 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 					'You can embed a specified rectangular area from a PDF page into your note. [Learn more](https://ryotaushio.github.io/obsidian-pdf-plus/embedding-rectangular-selections.html)'
 				], setting.descEl);
 			});
-		this.addSliderSetting('rectEmbedResolution', 10, 200, 1)
-			.setName('Rendering resolution')
-			.setDesc('The higher the value, the better the rendering quality, but the longer time it takes to render. The default value is 100.');
-		this.addToggleSetting('rectEmbedStaticImage', () => this.redisplay())
-			.setName('Paste as image')
-			.setDesc('By default, rectangular selection embeds are re-rendered every time you open the markdown file, which can slow down the loading time. Turn on this option to replace them with static images and improve the performance.');
-		if (this.plugin.settings.rectEmbedStaticImage) {
-			this.addDropdownSetting('rectImageFormat', { 'file': 'Create & embed image file', 'data-url': 'Embed as data URL' }, () => this.redisplay())
-				.setName('How to embed the image')
-				.then((setting) => this.renderMarkdown([
-					'- "Create & embed image file": Create an image file and embed it in the markdown file. The image file will be saved in the folder you specify in the "Default location for new attachments" setting in the core Obsidian settings.',
-					'- "Embed as data URL": Embed the image as a [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) without creating a file. This option is useful when you don\'t want to mess up your attachment folder. It also helps you make your notes self-contained.',
-				], setting.descEl));
-			if (this.plugin.settings.rectImageFormat === 'file') {
-				this.addDropdownSetting('rectImageExtension', IMAGE_EXTENSIONS)
-					.setName('Image file format');
+
+		this.addToggleSetting('rectEmbed', () => this.redisplay())
+			.setName('Embed Link')
+			.setDesc('If the link should embed the rectangular section or just give a link to it');
+
+		if(this.plugin.settings.rectEmbed) {
+			this.addSliderSetting('rectEmbedResolution', 10, 200, 1)
+				.setName('Rendering resolution')
+				.setDesc('The higher the value, the better the rendering quality, but the longer time it takes to render. The default value is 100.');
+			this.addToggleSetting('rectEmbedStaticImage', () => this.redisplay())
+				.setName('Paste as image')
+				.setDesc('By default, rectangular selection embeds are re-rendered every time you open the markdown file, which can slow down the loading time. Turn on this option to replace them with static images and improve the performance.');
+			if (this.plugin.settings.rectEmbedStaticImage) {
+				this.addDropdownSetting('rectImageFormat', { 'file': 'Create & embed image file', 'data-url': 'Embed as data URL' }, () => this.redisplay())
+					.setName('How to embed the image')
+					.then((setting) => this.renderMarkdown([
+						'- "Create & embed image file": Create an image file and embed it in the markdown file. The image file will be saved in the folder you specify in the "Default location for new attachments" setting in the core Obsidian settings.',
+						'- "Embed as data URL": Embed the image as a [data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs) without creating a file. This option is useful when you don\'t want to mess up your attachment folder. It also helps you make your notes self-contained.',
+					], setting.descEl));
+				if (this.plugin.settings.rectImageFormat === 'file') {
+					this.addDropdownSetting('rectImageExtension', IMAGE_EXTENSIONS)
+						.setName('Image file format');
+				}
 			}
 		}
 		this.addToggleSetting('includeColorWhenCopyingRectLink')


### PR DESCRIPTION
this MR adds a setting which in regards to rectangular settings gives an option in the settigns to only get the link into the clipboard instead of some kind of embeding with "!" or image. 
this is a partial step for [this feature request](https://github.com/RyotaUshio/obsidian-pdf-plus/issues/275)


i also noticed that generateMarkdownLink added conditionally a "!" to the beginning of the returnstring, which then just gets sliced off at almost every instance the function is called, so i switched that up.

I'm somewhat unfamiliar with obsidian plugin dev so this for sure will need doublechecking and is mostly a suggestion for the featurerequest i made.
Thanks for this great plugin 