### PR TITLE
:sparkles: support other `destId` type

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </p>
 
 > [!note] 
-> All contribution to this plugin has been made by a single voluntary student (me).
+> This plugin is maintained by a single voluntary student (me).
 > 
 > - If you like this plugin, don't forget to star this repository!
 > - If this plugin has become an important piece of your workflow, please consider [donation](#support-development) to show some love for this project.

--- a/src/bib.ts
+++ b/src/bib.ts
@@ -228,7 +228,7 @@ class BibliographyTextExtractor {
         const dests = await this.doc.getDestinations();
         const promises: Promise<void>[] = [];
         for (const destId in dests) {
-            if (destId.startsWith('cite.')) {
+            if (/^cite\.|^bib/.test(destId)) {
                 const destArray = dests[destId] as PDFJsDestArray;
                 promises.push(
                     this.extractBibTextForDest(destArray)

--- a/src/context-menu.ts
+++ b/src/context-menu.ts
@@ -631,7 +631,7 @@ export class PDFPlusContextMenu extends PDFPlusMenu {
                                 });
                         });
 
-                        if (destId.startsWith('cite.')) {
+                        if (plugin.lib.isCitationId(destId)) {
                             this.addItem((item) => {
                                 item.setSection('link')
                                     .setTitle('Search on Google Scholar')

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1009,4 +1009,8 @@ export class PDFPlusLib {
 
         return null;
     }
+
+    isCitationId(dest: string | PDFJsDestArray): dest is string {
+        return typeof dest === 'string' && this.plugin.citationIdRegex.test(dest);
+    }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -69,6 +69,7 @@ export default class PDFPlus extends Plugin {
 	/** Stores the file and the explicit destination array corresponding to the last link copied with the "Copy link to current page view" command */
 	lastCopiedDestInfo: { file: TFile, destArray: DestArray } | { file: TFile, destName: string } | null = null;
 	vimrc: string | null = null;
+	citationIdRegex: RegExp;
 	/** Maps a `div.pdf-viewer` element to the corresponding `PDFViewerChild` object. */
 	// In most use cases of this map, the goal is also achieved by using lib.workspace.iteratePDFViewerChild.
 	// However, a PDF embed inside a Canvas text node cannot be handled by the function, so we need this map.
@@ -163,6 +164,8 @@ export default class PDFPlus extends Plugin {
 
 	async loadSettings() {
 		this.settings = Object.assign(this.getDefaultSettings(), await this.loadData());
+
+		this.setCitationIdRegex();
 
 		// The AnyStyle path had been saved in data.json until v0.39.3, but now it's saved in the local storage
 		if (!this.settings.anystylePath) {
@@ -289,6 +292,13 @@ export default class PDFPlus extends Plugin {
 
 	saveLocalStorage(key: string, value?: any) {
 		this.app.saveLocalStorage(this.manifest.id + '-' + key, value);
+	}
+
+	setCitationIdRegex() {
+		const sources = this.settings.citationIdPatterns
+			.split(/\r?\n/)
+			.filter((line) => line.trim());
+		this.citationIdRegex = new RegExp(sources.join('|'));
 	}
 
 	/**

--- a/src/post-process/pdf-link-like.ts
+++ b/src/post-process/pdf-link-like.ts
@@ -3,7 +3,7 @@ import { App, HoverParent, HoverPopover, Keymap } from 'obsidian';
 import PDFPlus from 'main';
 import { PDFPlusLib } from 'lib';
 import { AnnotationElement, PDFOutlineTreeNode, PDFViewerChild, PDFJsDestArray } from 'typings';
-import { isCitationId, isMouseEventExternal, isTargetHTMLElement } from 'utils';
+import { isMouseEventExternal, isTargetHTMLElement } from 'utils';
 import { BibliographyManager } from 'bib';
 
 
@@ -214,7 +214,7 @@ export class PDFInternalLinkPostProcessor extends PDFDestinationHolderPostProces
         if (this.plugin.settings.actionOnCitationHover === 'google-scholar-popover'
             && this.lib.requirePluginNewerThan('surfing', '0.9.5')) {
             const destId = this.getDest();
-            if (isCitationId(destId)) {
+            if (this.lib.isCitationId(destId)) {
                 const doc = this.child.pdfViewer.pdfViewer?.pdfDocument;
                 if (doc) {
                     const url = this.child.bib?.getGoogleScholarSearchUrlFromDest(destId);
@@ -240,7 +240,7 @@ export class PDFInternalLinkPostProcessor extends PDFDestinationHolderPostProces
 
     isCitationLink() {
         const destId = this.getDest();
-        return isCitationId(destId);
+        return this.lib.isCitationId(destId);
     }
 
     get hoverLinkSourceId() {
@@ -258,7 +258,7 @@ export class PDFInternalLinkPostProcessor extends PDFDestinationHolderPostProces
         if (this.plugin.settings.actionOnCitationHover === 'pdf-plus-bib-popover'
             && this.child.bib && this.child.bib.isEnabled()) {
             const destId = this.getDest();
-            if (typeof destId === 'string' && destId.startsWith('cite.')) {
+            if (this.lib.isCitationId(destId)) {
                 this.child.bib.spawnBibPopoverOnModKeyDown(destId, this, evt, this.targetEl);
                 return true;
             }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -279,6 +279,7 @@ export interface PDFPlusSettings {
 	enableBibInEmbed: boolean;
 	enableBibInHoverPopover: boolean;
 	enableBibInCanvas: boolean;
+	citationIdPatterns: string;
 	copyAsSingleLine: boolean;
 	removeWhitespaceBetweenCJChars: boolean;
 	// Follows the same format as Obsidian's "Default location for new attachments
@@ -559,6 +560,7 @@ export const DEFAULT_SETTINGS: PDFPlusSettings = {
 	enableBibInEmbed: false,
 	enableBibInHoverPopover: false,
 	enableBibInCanvas: true,
+	citationIdPatterns: '^cite.\n^bib\\d+$',
 	copyAsSingleLine: true,
 	removeWhitespaceBetweenCJChars: true,
 	dummyFileFolderPath: '',
@@ -1008,7 +1010,7 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 				locationDropdown.setValue('root');
 				return;
 			}
-			if (value !== '.' && value !== './') {	
+			if (value !== '.' && value !== './') {
 				if (value.startsWith('./')) {
 					const subfolderName = value.slice(2);
 					locationDropdown.setValue('subfolder');
@@ -1016,7 +1018,7 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 					return;
 				}
 				locationDropdown.setValue('folder');
-				folderPathText.setValue(value !== defaultSubfolder ? defaultSubfolder : '');	
+				folderPathText.setValue(value !== defaultSubfolder ? defaultSubfolder : '');
 				return;
 			}
 			locationDropdown.setValue('current');
@@ -2600,6 +2602,13 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 						], setting.descEl);
 					}),
 				() => Platform.isDesktopApp && this.plugin.settings.actionOnCitationHover === 'pdf-plus-bib-popover'
+			);
+
+			this.showConditionally(
+				this.addTextAreaSetting('citationIdPatterns', undefined, () => this.plugin.setCitationIdRegex())
+					.setName('Citation ID patterns')
+					.setDesc('You don\'t need to care about this option in most use cases - just leave it to the default value. For advanced users: most internal links in PDF files use so-called destination names to specify the target location. This option allows you to specify the regular expressions (separated by line breaks) that determine whether a given internal link is a citation link based on the dsetination name.'),
+				() => this.plugin.settings.actionOnCitationHover !== 'none'
 			);
 
 			this.showConditionally(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,7 +1,7 @@
 import { Component, Modifier, Platform, CachedMetadata, ReferenceCache, parseLinktext, Menu, Scope, KeymapEventListener } from 'obsidian';
 import { PDFDict, PDFName, PDFRef } from '@cantoo/pdf-lib';
 
-import { ObsidianViewer, OldTextLayerBuilder, PDFJsDestArray, PDFPageView, Rect, TextContentItem, TextLayerBuilder } from 'typings';
+import { ObsidianViewer, OldTextLayerBuilder, PDFPageView, Rect, TextContentItem, TextLayerBuilder } from 'typings';
 
 export * from './color';
 export * from './suggest';
@@ -406,10 +406,6 @@ export function toSingleLine(str: string, removeWhitespaceBetweenCJChars = false
 export function encodeLinktext(linktext: string) {
     // eslint-disable-next-line no-control-regex
     return linktext.replace(/[\\\x00\x08\x0B\x0C\x0E-\x1F ]/g, (component) => encodeURIComponent(component));
-}
-
-export function isCitationId(dest: string | PDFJsDestArray): dest is string {
-    return typeof dest === 'string' && dest.startsWith('cite.');
 }
 
 /** Register a keymap that detects a certain character, e.g. "+", "=", "*". Works regardless of the user's keyboard layout. */


### PR DESCRIPTION
I found a case type === `XYZ` && has `top` `left`, but destId is startWith `bib`.

```json
{
    "start": 0,
    "end": 2,
    "rect": [
        507.742,
        723.345,
        515.962,
        733.323
    ],
    "str": "25",
    "page": 12,
    "rectDest": {
        "left": 303,
        "top": 489.986,
        "boundingRect": [
            [
                303,
                489.986
            ],
            [
                303,
                489.986
            ]
        ]
    },
    "type": "XYZ",
    "dest": "bib25",
    "color": {
        "0": 0,
        "1": 0,
        "2": 0
    }
}
```

pdf:
[doc (4).pdf](https://github.com/user-attachments/files/17974399/doc.4.pdf)
