### PR TITLE
Auto copied selections now only have 1 line, not 2, between it and the insertion point

### DIFF
--- a/src/lib/copy-link.ts
+++ b/src/lib/copy-link.ts
@@ -756,7 +756,7 @@ export class copyLinkLib extends PDFPlusLibSubmodule {
             } else {
                 let data = editor.getValue();
                 data = data.trimEnd();
-                if (data) data += '\n\n';
+                if (data) data += '\n';
                 data += text;
                 editor.setValue(data);
             }
@@ -775,7 +775,7 @@ export class copyLinkLib extends PDFPlusLibSubmodule {
             await this.app.vault.process(file, (data) => {
                 // If the file does not end with a blank line, add one
                 data = data.trimEnd();
-                if (data) data += '\n\n';
+                if (data) data += '\n';
                 data += text;
                 return data;
             });


### PR DESCRIPTION
Per the comment in the pasteTextToFile function "If the file does not end with a blank line, add one" only a single line should be added, but the code was adding 2 lines. This had the effect of inserting a blank line in between each auto copied selection.

Ps thank you! This is a great plug-in. I'll support it on ko-fi.