### PR TITLE
Add scholar support

### DIFF
--- a/src/bib.ts
+++ b/src/bib.ts
@@ -481,7 +481,6 @@ export class BibliographyDom extends PDFPlusComponent {
                         
                         if (params.title || params.bibstring) {
                             try {
-                                console.log(this.bib.scholarPlugin!.api);
                                 await this.bib.scholarPlugin!.api.openPaper(params);
                             } catch (error) {
                                 console.warn('Error calling searchPaperByTitle:', error);
@@ -491,13 +490,13 @@ export class BibliographyDom extends PDFPlusComponent {
                     });
                 
                 this.checkPaperInLibrary().then(isInLibrary => {
-                    console.log("isInLibrary", isInLibrary);
                     if (isInLibrary) {
                         scholarButton.setButtonText('📚 Open in Scholar Library');
-                        scholarButton.buttonEl.style.color = '#4CAF50'; // Green
+                        scholarButton.buttonEl.style.color = '#1971c2'; // oc-blue-8
                     } else {
                         scholarButton.setButtonText('🔍 Search with Scholar');
-                        scholarButton.buttonEl.style.color = '#757575'; // Gray
+                        // scholarButton.buttonEl.style.color = '#757575'; // Gray
+                        // We just don't change the color here 
                     }
                 }).catch((error) => {
                     console.warn('Error checking paper in scholar library:', error);

--- a/src/bib.ts
+++ b/src/bib.ts
@@ -468,7 +468,7 @@ export class BibliographyDom extends PDFPlusComponent {
                 });
             
             // Add scholar library search button
-            if (this.bib.scholarPlugin) {
+            if (this.bib.scholarPlugin && this.settings.showScholarButtonInBibPopups) {
                 const scholarButton = new ButtonComponent(el)
                     .setButtonText('📚 Checking...')
                     .onClick(async () => {

--- a/src/bib.ts
+++ b/src/bib.ts
@@ -38,6 +38,10 @@ export class BibliographyManager extends PDFPlusComponent {
         this.init();
     }
 
+    get scholarPlugin() {
+        return this.app.plugins.plugins.scholar ?? null;
+    }
+
     isEnabled() {
         const viewer = this.child.pdfViewer;
         return this.settings.actionOnCitationHover !== 'none'
@@ -342,6 +346,50 @@ export class BibliographyDom extends PDFPlusComponent {
         return this.bib.child;
     }
 
+    private async checkPaperInLibrary(): Promise<boolean> {
+        const scholarPlugin = this.bib.scholarPlugin;
+        if (!scholarPlugin || !scholarPlugin.api) {
+            console.debug('Scholar plugin not available');
+            return false;
+        }
+
+        const parsed = this.bib.destIdToParsedBib.get(this.destId);
+        const bibText = this.bib.destIdToBibText.get(this.destId);
+
+        let url: string | undefined;
+        let title: string | undefined;
+
+        // Use structured data when available
+        if (parsed) {
+            title = parsed.title?.[0];
+            // You could also extract URL from other parsed fields if needed
+            console.debug('Using parsed data - title:', title);
+        }
+
+        // Prepare parameters for the API call
+        const params: { url?: string, title?: string, citekey?: string, bibstring?: string } = {};
+        
+        if (title) params.title = title;
+        if (url) params.url = url;
+        if (bibText) params.bibstring = bibText;
+
+        // Need at least some data to make the call
+        if (!params.title && !params.url && !params.bibstring) {
+            console.debug('No data available for library check');
+            return false;
+        }
+
+        try {
+            console.debug('Calling scholar API with params:', params);
+            const result = await scholarPlugin.api.isPaperInLibrary(params);
+            console.debug('Scholar API result:', result?.isInLibrary || false);
+            return result?.isInLibrary || false;
+        } catch (error) {
+            console.debug('Error checking paper in scholar library:', error);
+            return false;
+        }
+    }
+
     renderParsedBib(parsed: AnystyleJson) {
         const { author, title, year, 'container-title': containerTitle } = parsed;
 
@@ -418,6 +466,46 @@ export class BibliographyDom extends PDFPlusComponent {
                     }
                     window.open(url);
                 });
+            
+            // Add scholar library search button
+            if (this.bib.scholarPlugin) {
+                const scholarButton = new ButtonComponent(el)
+                    .setButtonText('📚 Checking...')
+                    .onClick(async () => {
+                        const parsed = this.bib.destIdToParsedBib.get(this.destId);
+                        const bibText = this.bib.destIdToBibText.get(this.destId);
+                        
+                        const params: { title?: string, bibstring?: string } = {};
+                        if (parsed?.title?.[0]) params.title = parsed.title[0];
+                        if (bibText) params.bibstring = bibText;
+                        
+                        if (params.title || params.bibstring) {
+                            try {
+                                console.log(this.bib.scholarPlugin!.api);
+                                await this.bib.scholarPlugin!.api.openPaper(params);
+                            } catch (error) {
+                                console.warn('Error calling searchPaperByTitle:', error);
+                                new Notice(`${this.plugin.manifest.name}: Failed to search in Scholar`);
+                            }
+                        }
+                    });
+                
+                this.checkPaperInLibrary().then(isInLibrary => {
+                    console.log("isInLibrary", isInLibrary);
+                    if (isInLibrary) {
+                        scholarButton.setButtonText('📚 Open in Scholar Library');
+                        scholarButton.buttonEl.style.color = '#4CAF50'; // Green
+                    } else {
+                        scholarButton.setButtonText('🔍 Search with Scholar');
+                        scholarButton.buttonEl.style.color = '#757575'; // Gray
+                    }
+                }).catch((error) => {
+                    console.warn('Error checking paper in scholar library:', error);
+                    scholarButton.setButtonText('❓ Search with Scholar');
+                    scholarButton.buttonEl.style.color = '#FF9800'; // Orange
+                });
+            }
+            
             new ExtraButtonComponent(el)
                 .setIcon('lucide-settings')
                 .setTooltip('Customize...')

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -282,6 +282,7 @@ export interface PDFPlusSettings {
 	enableBibInEmbed: boolean;
 	enableBibInHoverPopover: boolean;
 	enableBibInCanvas: boolean;
+	showScholarButtonInBibPopups: boolean;
 	citationIdPatterns: string;
 	copyAsSingleLine: boolean;
 	removeWhitespaceBetweenCJChars: boolean;
@@ -569,6 +570,7 @@ export const DEFAULT_SETTINGS: PDFPlusSettings = {
 	enableBibInEmbed: false,
 	enableBibInHoverPopover: false,
 	enableBibInCanvas: true,
+	showScholarButtonInBibPopups: true,
 	citationIdPatterns: '^cite.\n^bib\\d+$',
 	copyAsSingleLine: true,
 	removeWhitespaceBetweenCJChars: true,
@@ -2643,6 +2645,8 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 				() => this.plugin.settings.actionOnCitationHover !== 'none'
 			);
 
+
+
 			this.showConditionally(
 				[
 					this.addDesc('Try turning off the following options if you experience performance issues.'),
@@ -2656,6 +2660,22 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 				() => this.plugin.settings.actionOnCitationHover !== 'none',
 			);
 		}
+
+
+		this.addHeading('Obsidian Scholar integration', 'scholar-integration', 'lucide-book-plus')
+			.setDesc('Enhance your bibliography experience with the Obsidian Scholar plugin integration.');
+		this.addToggleSetting('showScholarButtonInBibPopups')
+			.setName('Show scholar buttons in bibliography popups')
+			.setDesc('If the Obsidian Scholar plugin is installed, it will show buttons to search for papers or open them directly in your Scholar library.')
+			.then((setting) => {
+				this.renderMarkdown([
+					'**Note:** This requires the [Obsidian Scholar](obsidian://show-plugin?id=scholar) plugin to be installed and enabled.',
+					'',
+					'When enabled, bibliography popups will include buttons to:',
+					'- 🔍 Search for the paper in Scholar',
+					'- 📚 Open the paper in your Scholar library (if it\'s already there)',
+				], setting.descEl);
+			});
 
 
 		this.addHeading('External links in PDF', 'pdf-external-link', 'external-link')

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1102,6 +1102,12 @@ declare module 'obsidian' {
                 ['obsidian-tts']?: Plugin & {
                     say(text: string, languageCode?: string): Promise<void>
                 };
+                scholar?: Plugin & {
+                    api: {
+                        isPaperInLibrary(params: { url?: string, title?: string, citekey?: string, bibstring?: string }): Promise<{ isInLibrary: boolean }>;
+                        openPaper(params: { title?: string, bibstring?: string }): Promise<void>;
+                    };
+                };
                 [id: string]: Plugin | undefined;
             }
             enabledPlugins: Set<string>;


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.

---

### Description

Supporting the connection with the [Obsidian Scholar](https://github.com/lolipopshock/obsidian-scholar) Plugin: 

1. Update the settings menu 
    <img width="795" alt="image" src="https://github.com/user-attachments/assets/e0147271-619a-478a-a46c-59023a34979e" />
2. If enabled and the scholar plugin is installed, it can add an additional button to any bib popups: 
    - When the paper is not in the scholar library, it can prompt to search for the paper and add to the library 
    - Otherwise it can just open the paper in the library and the corresponding pdfs
    - See the demo below: 

    https://github.com/user-attachments/assets/b66a8a00-cedc-48fa-9c7c-4e44a6c356d8



