### PR TITLE
Add PDF form saving/editing feature #522

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "keywords": [],
     "author": "Ryota Ushio",
     "license": "MIT",
+    "dependencies": {
+        "@cantoo/pdf-lib": "^2.4.3"
+    },
     "devDependencies": {
-        "@cantoo/pdf-lib": "^2.4.3",
         "@capacitor/app": "^7.0.2",
         "@capacitor/core": "^7.4.3",
         "@capacitor/device": "^7.0.2",

--- a/src/color-palette.ts
+++ b/src/color-palette.ts
@@ -24,6 +24,8 @@ export class ColorPalette extends PDFPlusComponent {
     displayTextFormatMenuEl: HTMLElement | null;
     writeFileButtonEl: HTMLElement | null;
     saveFormButtonEl: HTMLElement | null;
+    saveFormIndicatorEl: HTMLElement | null;
+    unregisterFormStateListener: (() => void) | null;
     cropButtonEl: HTMLElement | null;
     statusContainerEl: HTMLElement | null;
     statusEl: HTMLElement | null;
@@ -47,6 +49,8 @@ export class ColorPalette extends PDFPlusComponent {
         this.displayTextFormatMenuEl = null;
         this.writeFileButtonEl = null;
         this.saveFormButtonEl = null;
+        this.saveFormIndicatorEl = null;
+        this.unregisterFormStateListener = null;
         this.cropButtonEl = null;
         this.statusContainerEl = null;
         this.statusEl = null;
@@ -401,13 +405,38 @@ export class ColorPalette extends PDFPlusComponent {
                 }
 
                 try {
+                    el.addClass('is-active');
                     await this.lib.forms.saveFormFields(this.child);
                 } catch (e) {
                     new Notice(`${this.plugin.manifest.name}: Failed to save PDF form fields.`);
                     console.error(e);
+                } finally {
+                    el.removeClass('is-active');
                 }
             });
         });
+
+        this.saveFormIndicatorEl = paletteEl.createSpan('pdf-plus-form-save-indicator');
+
+        // Position save button and indicator together after the write-file toggle.
+        if (this.writeFileButtonEl) {
+            paletteEl.insertAfter(this.saveFormButtonEl, this.writeFileButtonEl);
+        }
+        // Always position indicator right after the save button.
+        if (this.saveFormButtonEl && this.saveFormIndicatorEl) {
+            this.saveFormButtonEl.insertAdjacentElement('afterend', this.saveFormIndicatorEl);
+        }
+
+        this.unregisterFormStateListener = this.lib.forms.registerStateListener(this.child, ({ dirty, saving, progress }) => {
+            this.updateFormSaveIndicator(dirty, saving, progress);
+        });
+
+        // Push initial state so the indicator shows "Unsaved" if the form was already dirty.
+        this.updateFormSaveIndicator(
+            this.lib.forms.isDirty(this.child),
+            this.lib.forms.isSaving(this.child),
+            0,
+        );
 
         // Hide the button if no forms are detected.
         (async () => {
@@ -420,15 +449,38 @@ export class ColorPalette extends PDFPlusComponent {
                 // ignore
             }
         })();
-
-        if (this.writeFileButtonEl) {
-            paletteEl.insertAfter(this.saveFormButtonEl, this.writeFileButtonEl);
-        }
     }
 
     removeSaveFormButton() {
+        this.unregisterFormStateListener?.();
+        this.unregisterFormStateListener = null;
         this.saveFormButtonEl?.remove();
         this.saveFormButtonEl = null;
+        this.saveFormIndicatorEl?.remove();
+        this.saveFormIndicatorEl = null;
+    }
+
+    private updateFormSaveIndicator(dirty: boolean, saving: boolean, progress: number) {
+        const el = this.saveFormIndicatorEl;
+        if (!el) return;
+
+        if (saving) {
+            const pct = Math.min(99, Math.max(0, Math.round(progress)));
+            el.setText(`${pct}%`);
+            el.toggleClass('is-saving', true);
+            el.toggleClass('is-dirty', false);
+            el.style.display = 'inline-flex';
+        } else if (dirty) {
+            el.setText('Unsaved');
+            el.toggleClass('is-saving', false);
+            el.toggleClass('is-dirty', true);
+            el.style.display = 'inline-flex';
+        } else {
+            el.setText('');
+            el.toggleClass('is-saving', false);
+            el.toggleClass('is-dirty', false);
+            el.style.display = 'none';
+        }
     }
 
     addImportButton(paletteEl: HTMLElement) {

--- a/src/color-palette.ts
+++ b/src/color-palette.ts
@@ -102,6 +102,7 @@ export class ColorPalette extends PDFPlusComponent {
     }
 
     onunload() {
+        this.removeSaveFormButton();
         this.spacerEl?.remove();
         if (this.paletteEl) {
             this.paletteEl.remove();

--- a/src/color-palette.ts
+++ b/src/color-palette.ts
@@ -23,6 +23,7 @@ export class ColorPalette extends PDFPlusComponent {
     actionMenuEl: HTMLElement | null;
     displayTextFormatMenuEl: HTMLElement | null;
     writeFileButtonEl: HTMLElement | null;
+    saveFormButtonEl: HTMLElement | null;
     cropButtonEl: HTMLElement | null;
     statusContainerEl: HTMLElement | null;
     statusEl: HTMLElement | null;
@@ -45,6 +46,7 @@ export class ColorPalette extends PDFPlusComponent {
         this.actionMenuEl = null;
         this.displayTextFormatMenuEl = null;
         this.writeFileButtonEl = null;
+        this.saveFormButtonEl = null;
         this.cropButtonEl = null;
         this.statusContainerEl = null;
         this.statusEl = null;
@@ -84,6 +86,7 @@ export class ColorPalette extends PDFPlusComponent {
             this.addImportButton(this.paletteEl);
         } else {
             this.addWriteFileToggle(this.paletteEl);
+            this.addSaveFormButton(this.paletteEl);
         }
 
         this.statusContainerEl = this.paletteEl.createDiv('pdf-plus-color-palette-status-container');
@@ -370,6 +373,62 @@ export class ColorPalette extends PDFPlusComponent {
     removeWriteFileToggle() {
         this.writeFileButtonEl?.remove();
         this.writeFileButtonEl = null;
+    }
+
+    addSaveFormButton(paletteEl: HTMLElement) {
+        this.removeSaveFormButton();
+
+        if (!this.plugin.settings.enablePdfFormSave) return;
+
+        this.saveFormButtonEl = paletteEl.createDiv('clickable-icon', (el) => {
+            setIcon(el, 'lucide-save');
+            setTooltip(el, 'Save PDF form fields');
+            el.toggleClass('is-disabled', !this.lib.isEditable(this.child));
+
+            el.addEventListener('click', async () => {
+                if (!this.lib.isEditable(this.child)) {
+                    const menu = new Menu()
+                        .addItem((item) => {
+                            item.setIcon('lucide-settings')
+                                .setTitle('Enable PDF editing...')
+                                .onClick(() => {
+                                    this.plugin.openSettingTab()
+                                        .scrollToHeading('edit');
+                                });
+                        });
+                    showMenuUnderParentEl(menu, el);
+                    return;
+                }
+
+                try {
+                    await this.lib.forms.saveFormFields(this.child);
+                } catch (e) {
+                    new Notice(`${this.plugin.manifest.name}: Failed to save PDF form fields.`);
+                    console.error(e);
+                }
+            });
+        });
+
+        // Hide the button if no forms are detected.
+        (async () => {
+            try {
+                const hasForms = await this.lib.forms.hasForms(this.child);
+                if (!hasForms) {
+                    this.removeSaveFormButton();
+                }
+            } catch {
+                // ignore
+            }
+        })();
+
+        if (this.writeFileButtonEl) {
+            paletteEl.insertAfter(this.saveFormButtonEl, this.writeFileButtonEl);
+        }
+    }
+
+    removeSaveFormButton() {
+        this.saveFormButtonEl?.remove();
+        this.saveFormButtonEl = null;
     }
 
     addImportButton(paletteEl: HTMLElement) {

--- a/src/context-menu.ts
+++ b/src/context-menu.ts
@@ -502,6 +502,22 @@ export class PDFPlusContextMenu extends PDFPlusMenu {
             });
         }
 
+        // Save form fields into the PDF file
+        if (lib.isEditable(child) && plugin.settings.enablePdfFormSave && isVisible('action')) {
+            const hasForms = await lib.forms.hasForms(child);
+            if (hasForms) {
+                this.addItem((item) => {
+                    return item
+                        .setSection('action')
+                        .setTitle('Save PDF form fields')
+                        .setIcon('lucide-save')
+                        .onClick(() => {
+                            lib.forms.saveFormFields(child).catch((e) => console.error(e));
+                        });
+                });
+            }
+        }
+
         //// Add items ////
 
         if (selectedText) {

--- a/src/context-menu.ts
+++ b/src/context-menu.ts
@@ -512,7 +512,10 @@ export class PDFPlusContextMenu extends PDFPlusMenu {
                         .setTitle('Save PDF form fields')
                         .setIcon('lucide-save')
                         .onClick(() => {
-                            lib.forms.saveFormFields(child).catch((e) => console.error(e));
+                            lib.forms.saveFormFields(child).catch((e) => {
+                                new Notice(`${plugin.manifest.name}: Failed to save PDF form fields.`);
+                                console.error(e);
+                            });
                         });
                 });
             }

--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -113,6 +113,10 @@ export class PDFPlusCommands extends PDFPlusLibSubmodule {
                 name: 'Disable PDF edit',
                 checkCallback: (checking) => this.setWriteFile(checking, false)
             }, {
+                id: 'save-pdf-form-fields',
+                name: 'Save PDF form fields',
+                checkCallback: (checking) => this.savePdfFormFields(checking)
+            }, {
                 id: 'toggle-auto-focus',
                 name: 'Toggle auto-focus',
                 callback: () => this.toggleAutoFocus()
@@ -558,6 +562,26 @@ export class PDFPlusCommands extends PDFPlusLibSubmodule {
         if (!checking) {
             palette.setWriteFile(writeFile);
         }
+        return true;
+    }
+
+    savePdfFormFields(checking: boolean) {
+        const child = this.lib.getPDFViewerChild(true);
+        if (!child) return false;
+        if (!this.settings.enablePdfFormSave) return false;
+        if (!this.lib.isEditable(child)) return false;
+
+        if (!checking) {
+            (async () => {
+                try {
+                    await this.lib.forms.saveFormFields(child);
+                } catch (e) {
+                    new Notice(`${this.plugin.manifest.name}: Failed to save PDF form fields.`);
+                    console.error(e);
+                }
+            })();
+        }
+
         return true;
     }
 

--- a/src/lib/forms/index.ts
+++ b/src/lib/forms/index.ts
@@ -4,7 +4,7 @@ import { PDFDocument } from '@cantoo/pdf-lib';
 
 import PDFPlus from 'main';
 import { PDFPlusLibSubmodule } from 'lib/submodule';
-import { PDFViewerChild } from 'typings';
+import { ObsidianViewer, PDFPageView, PDFViewerChild } from 'typings';
 
 export type PdfFormFieldValue = string | string[] | boolean | null;
 
@@ -32,11 +32,23 @@ export interface CollectedPdfFormState {
     fields: Map<string, CollectedPdfFormFieldState>;
 }
 
+export type FormSaveStateListener = (info: { dirty: boolean; saving: boolean; progress: number }) => void;
+
 type ChildSaveState = {
     dirty: boolean;
     inFlight: boolean;
     queued: boolean;
+    queuedSilent: boolean;
     timerId: number | null;
+};
+
+type CachedPdfDoc = {
+    pdfDoc: PDFDocument;
+    writeMtime: number;
+};
+
+type PDFDocumentLike = {
+    getFieldObjects?: () => Promise<unknown>;
 };
 
 function isRecord(value: unknown): value is Record<string, any> {
@@ -79,6 +91,13 @@ function coerceToFieldValue(value: unknown): PdfFormFieldValue {
 
 export class PdfFormsLib extends PDFPlusLibSubmodule {
     private childState = new WeakMap<PDFViewerChild, ChildSaveState>();
+    private autoFitRegistered = new WeakSet<PDFViewerChild>();
+    private autoFitRafByEl = new WeakMap<HTMLElement, number>();
+    private textMeasureCtx: CanvasRenderingContext2D | null = null;
+
+    private pdfDocCache = new Map<string, CachedPdfDoc>();
+    private stateListeners = new WeakMap<PDFViewerChild, Set<FormSaveStateListener>>();
+    private preloadingFiles = new Set<string>();
 
     constructor(plugin: PDFPlus) {
         super(plugin);
@@ -87,15 +106,18 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
     private getState(child: PDFViewerChild): ChildSaveState {
         let state = this.childState.get(child);
         if (!state) {
-            state = { dirty: false, inFlight: false, queued: false, timerId: null };
+            state = { dirty: false, inFlight: false, queued: false, queuedSilent: true, timerId: null };
             this.childState.set(child, state);
         }
         return state;
     }
 
     isEnabled() {
-        // This feature is a subset of “editing PDF files”, so keep it behind the same safety gate.
         return this.plugin.settings.enablePDFEdit && this.plugin.settings.enablePdfFormSave;
+    }
+
+    private isAutoFitEnabled() {
+        return true;
     }
 
     isAutoSaveEnabled() {
@@ -107,11 +129,129 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
         return typeof ms === 'number' && Number.isFinite(ms) ? Math.max(0, ms) : 2000;
     }
 
-    /**
-     * Register event listeners that mark the PDF forms as dirty and optionally auto-save.
-     * This should be called after the viewer DOM is ready.
-     */
+    isDirty(child: PDFViewerChild): boolean {
+        return this.getState(child).dirty;
+    }
+
+    isSaving(child: PDFViewerChild): boolean {
+        return this.getState(child).inFlight;
+    }
+
+    registerStateListener(child: PDFViewerChild, cb: FormSaveStateListener): () => void {
+        let listeners = this.stateListeners.get(child);
+        if (!listeners) {
+            listeners = new Set();
+            this.stateListeners.set(child, listeners);
+        }
+        listeners.add(cb);
+        return () => listeners!.delete(cb);
+    }
+
+    private notifyListeners(child: PDFViewerChild, progress: number) {
+        const state = this.getState(child);
+        const listeners = this.stateListeners.get(child);
+        if (!listeners) return;
+        const info = { dirty: state.dirty, saving: state.inFlight, progress };
+        for (const cb of listeners) {
+            try { cb(info); } catch { /* ignore */ }
+        }
+    }
+
+    // --- PDFDocument caching ---
+
+    private async getOrLoadPdfDoc(file: TFile): Promise<PDFDocument> {
+        const cached = this.pdfDocCache.get(file.path);
+        if (cached && file.stat.mtime === cached.writeMtime) {
+            return cached.pdfDoc;
+        }
+        const pdfDoc = await this.lib.loadPdfLibDocument(file);
+        this.pdfDocCache.delete(file.path);
+        return pdfDoc;
+    }
+
+    private cachePdfDoc(file: TFile, pdfDoc: PDFDocument) {
+        this.pdfDocCache.set(file.path, { pdfDoc, writeMtime: file.stat.mtime });
+    }
+
+    invalidatePdfDocCache(filePath: string) {
+        this.pdfDocCache.delete(filePath);
+    }
+
+    private preloadPdfDoc(child: PDFViewerChild) {
+        const file = child.file;
+        if (!(file instanceof TFile)) return;
+        if (this.pdfDocCache.has(file.path)) return;
+        if (this.preloadingFiles.has(file.path)) return;
+
+        this.preloadingFiles.add(file.path);
+        this.lib.loadPdfLibDocument(file).then((pdfDoc) => {
+            if (!this.pdfDocCache.has(file.path)) {
+                this.pdfDocCache.set(file.path, { pdfDoc, writeMtime: file.stat.mtime });
+            }
+        }).catch(() => {}).finally(() => {
+            this.preloadingFiles.delete(file.path);
+        });
+    }
+
+    // --- Autosave scheduling ---
+
+    private scheduleAutoSave(child: PDFViewerChild, delayMs: number) {
+        const state = this.getState(child);
+        if (state.timerId !== null) {
+            window.clearTimeout(state.timerId);
+        }
+        state.timerId = window.setTimeout(() => {
+            state.timerId = null;
+            if (!state.dirty) return;
+
+            if (this.isActivelyEditingFormField(child)) {
+                this.scheduleAutoSave(child, 400);
+                return;
+            }
+
+            this.saveFormFields(child, { silent: true }).catch((e) => console.error(e));
+        }, Math.max(0, delayMs));
+    }
+
+    private isActivelyEditingFormField(child: PDFViewerChild): boolean {
+        const viewerContainerEl = child.pdfViewer?.dom?.viewerContainerEl;
+        if (!viewerContainerEl) return false;
+
+        const doc = viewerContainerEl.doc ?? viewerContainerEl.ownerDocument;
+        const activeEl = doc?.activeElement;
+        if (!(activeEl instanceof HTMLElement)) return false;
+        if (!viewerContainerEl.contains(activeEl)) return false;
+        if (!activeEl.matches('input, textarea, select')) return false;
+        return !!activeEl.closest('.annotationLayer');
+    }
+
+    private async waitForPdfDocument(child: PDFViewerChild): Promise<PDFDocumentLike | null> {
+        const currentDoc = child.pdfViewer?.pdfViewer?.pdfDocument as PDFDocumentLike | null | undefined;
+        if (currentDoc) return currentDoc;
+
+        const viewer = child.pdfViewer ?? null;
+        if (!viewer) return null;
+
+        return await new Promise<PDFDocumentLike | null>((resolve) => {
+            let resolved = false;
+            const done = (doc: PDFDocumentLike | null) => {
+                if (resolved) return;
+                resolved = true;
+                resolve(doc);
+            };
+
+            this.lib.onDocumentReady(viewer, (doc) => done((doc as PDFDocumentLike) ?? null));
+            window.setTimeout(() => {
+                done((child.pdfViewer?.pdfViewer?.pdfDocument as PDFDocumentLike | null) ?? null);
+            }, 2000);
+        });
+    }
+
+    // --- Form change listeners ---
+
     registerFormChangeListeners(child: PDFViewerChild, viewerContainerEl: HTMLElement) {
+        this.registerAutoFitTextInForms(child, viewerContainerEl);
+
         if (!this.isEnabled()) return;
 
         const handler = (evt: Event) => {
@@ -121,32 +261,204 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
             this.markDirty(child);
         };
 
-        // Capture phase so we see changes early and reliably.
         child.component?.registerDomEvent(viewerContainerEl, 'input', handler, { capture: true });
         child.component?.registerDomEvent(viewerContainerEl, 'change', handler, { capture: true });
     }
 
-    markDirty(child: PDFViewerChild) {
-        const state = this.getState(child);
-        state.dirty = true;
+    private static readonly NON_TEXT_TYPES = new Set([
+        'checkbox', 'radio', 'button', 'submit', 'reset', 'file', 'image', 'range', 'color',
+    ]);
 
-        if (!this.isAutoSaveEnabled()) return;
+    private registerAutoFitTextInForms(child: PDFViewerChild, _viewerContainerEl: HTMLElement) {
+        if (!this.isAutoFitEnabled()) return;
+        if (this.autoFitRegistered.has(child)) return;
+        this.autoFitRegistered.add(child);
 
-        if (state.timerId !== null) {
-            window.clearTimeout(state.timerId);
-        }
+        const viewer: ObsidianViewer | null = child.pdfViewer ?? null;
+        if (!viewer) return;
 
-        state.timerId = window.setTimeout(() => {
-            state.timerId = null;
-            this.saveFormFields(child, { silent: true }).catch((e) => console.error(e));
-        }, this.getAutoSaveDebounceMs());
+        this.lib.onAnnotationLayerReady(viewer, child.component ?? null, (_pageNumber: number, pageView: PDFPageView) => {
+            const layer = pageView.annotationLayer?.div;
+            if (!layer) return;
+            this.setupAutoFitForLayer(layer);
+        });
+
+        window.setTimeout(() => {
+            const viewerEl = child.pdfViewer?.dom?.viewerEl;
+            if (viewerEl) this.setupAutoFitForLayer(viewerEl);
+        }, 0);
     }
 
-    async hasForms(child: PDFViewerChild): Promise<boolean> {
-        const doc = child.pdfViewer.pdfViewer?.pdfDocument;
-        if (!doc) return false;
+    private isTextFormControl(el: Element): el is HTMLInputElement | HTMLTextAreaElement {
+        if (el instanceof HTMLTextAreaElement) return true;
+        if (!(el instanceof HTMLInputElement)) return false;
+        const type = (el.getAttribute('type') ?? el.type ?? 'text').toLowerCase();
+        return !PdfFormsLib.NON_TEXT_TYPES.has(type);
+    }
 
-        const getFieldObjects = (doc as any).getFieldObjects;
+    private setupAutoFitForLayer(root: ParentNode) {
+        const controls = root.querySelectorAll<HTMLInputElement | HTMLTextAreaElement>(
+            '.annotationLayer input, .annotationLayer textarea',
+        );
+        for (const el of controls) {
+            if (!this.isTextFormControl(el)) continue;
+
+            if (el.dataset.pdfPlusAutoFitBound === 'true') {
+                this.fitTextControlToBox(el);
+                continue;
+            }
+            el.dataset.pdfPlusAutoFitBound = 'true';
+
+            const onInput = () => {
+                const existing = this.autoFitRafByEl.get(el);
+                if (existing) cancelAnimationFrame(existing);
+                this.autoFitRafByEl.set(el, requestAnimationFrame(() => {
+                    this.autoFitRafByEl.delete(el);
+                    this.fitTextControlToBox(el);
+                }));
+            };
+            el.addEventListener('input', onInput);
+            el.addEventListener('change', onInput);
+
+            this.fitTextControlToBox(el);
+        }
+    }
+
+    private fitTextControlToBox(el: HTMLInputElement | HTMLTextAreaElement) {
+        if (!el.isConnected) return;
+        if (!el.closest('.annotationLayer')) return;
+
+        const section = el.closest<HTMLElement>('section[data-annotation-id]');
+        const visualRect = (section ?? el).getBoundingClientRect();
+        const availableW = Math.max(0, visualRect.width - 2);
+        const availableH = Math.max(0, visualRect.height - 2);
+        if (availableW <= 2 || availableH <= 2) return;
+
+        const ds = el.dataset;
+        const computed = window.getComputedStyle(el);
+        const storedBase = ds.pdfPlusAutoFitBaseFontSize;
+        const rawBase = storedBase ? parseFloat(storedBase) : (parseFloat(computed.fontSize) || 12);
+        if (!storedBase) ds.pdfPlusAutoFitBaseFontSize = String(rawBase);
+
+        const minFontSize = 4;
+        const value = el.value ?? '';
+
+        const maxByHeight = el instanceof HTMLTextAreaElement
+            ? Math.max(minFontSize, availableH * 0.45)
+            : Math.max(minFontSize, availableH * 0.72);
+
+        let maxStartSize = maxByHeight;
+        if (el instanceof HTMLTextAreaElement && value) {
+            const explicitLineCount = Math.max(1, value.split(/\r\n|\r|\n/).length);
+            const maxByLineCount = Math.max(minFontSize, (availableH / explicitLineCount) * 0.9);
+            maxStartSize = Math.max(minFontSize, Math.min(maxStartSize, maxByLineCount));
+        }
+
+        maxStartSize = Math.max(minFontSize, Math.min(maxStartSize, Math.max(rawBase, minFontSize)));
+
+        const fits = () => {
+            if (el instanceof HTMLTextAreaElement) {
+                return el.scrollHeight <= el.clientHeight + 1 && el.scrollWidth <= el.clientWidth + 1;
+            }
+            return this.singleLineInputFits(el, value);
+        };
+
+        if (!value) {
+            el.style.setProperty('font-size', `${maxStartSize}px`, 'important');
+            return;
+        }
+
+        let low = minFontSize;
+        let high = Math.max(minFontSize, maxStartSize);
+        let best = minFontSize;
+
+        el.style.setProperty('font-size', `${high}px`, 'important');
+        if (fits()) {
+            return;
+        }
+
+        el.style.setProperty('font-size', `${low}px`, 'important');
+        if (!fits()) {
+            return;
+        }
+
+        for (let i = 0; i < 12; i++) {
+            const mid = (low + high) / 2;
+            el.style.setProperty('font-size', `${mid}px`, 'important');
+            if (fits()) {
+                best = mid;
+                low = mid;
+            } else {
+                high = mid;
+            }
+        }
+
+        el.style.setProperty('font-size', `${best}px`, 'important');
+    }
+
+    private getTextMeasureContext() {
+        if (this.textMeasureCtx) return this.textMeasureCtx;
+        const canvas = document.createElement('canvas');
+        this.textMeasureCtx = canvas.getContext('2d');
+        return this.textMeasureCtx;
+    }
+
+    private singleLineInputFits(el: HTMLInputElement, value: string) {
+        const ctx = this.getTextMeasureContext();
+        if (!ctx) {
+            return el.scrollWidth <= el.clientWidth + 1;
+        }
+
+        const style = window.getComputedStyle(el);
+        const paddingX = (parseFloat(style.paddingLeft) || 0) + (parseFloat(style.paddingRight) || 0);
+        const availableTextWidth = Math.max(0, el.clientWidth - paddingX - 2);
+        if (availableTextWidth <= 1) return false;
+
+        const fontStyle = style.fontStyle || 'normal';
+        const fontVariant = style.fontVariant || 'normal';
+        const fontWeight = style.fontWeight || '400';
+        const fontSize = style.fontSize || '12px';
+        const fontFamily = style.fontFamily || 'sans-serif';
+        ctx.font = `${fontStyle} ${fontVariant} ${fontWeight} ${fontSize} ${fontFamily}`;
+
+        const text = value || '';
+        let width = ctx.measureText(text).width;
+
+        const letterSpacing = parseFloat(style.letterSpacing);
+        if (Number.isFinite(letterSpacing) && text.length > 1) {
+            width += letterSpacing * (text.length - 1);
+        }
+
+        return width <= availableTextWidth + 0.5;
+    }
+
+    // --- Dirty tracking ---
+
+    markDirty(child: PDFViewerChild) {
+        const state = this.getState(child);
+        const wasDirty = state.dirty;
+        state.dirty = true;
+
+        if (!wasDirty) {
+            this.preloadPdfDoc(child);
+        }
+
+        // Always notify so the UI indicator stays in sync even across viewer reloads.
+        this.notifyListeners(child, 0);
+
+        if (!this.isAutoSaveEnabled()) return;
+        this.scheduleAutoSave(child, this.getAutoSaveDebounceMs());
+    }
+
+    // --- Form detection ---
+
+    async hasForms(child: PDFViewerChild): Promise<boolean> {
+        let doc = child.pdfViewer.pdfViewer?.pdfDocument as PDFDocumentLike | null | undefined;
+        if (!doc) {
+            doc = await this.waitForPdfDocument(child);
+        }
+
+        const getFieldObjects = doc?.getFieldObjects;
         if (typeof getFieldObjects === 'function') {
             try {
                 const fieldObjects = await getFieldObjects.call(doc);
@@ -156,16 +468,14 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
             }
         }
 
-        // Fallback: if any form control exists in rendered annotation layers, treat as forms present.
         if (child.pdfViewer.dom?.viewerEl?.querySelector('.annotationLayer input, .annotationLayer textarea, .annotationLayer select')) {
             return true;
         }
 
-        return false;
+        return !doc;
     }
 
     private getAnnotationStorage(child: PDFViewerChild): any | null {
-        // Best-effort: Obsidian’s PDF.js may expose it in different places across versions.
         const pages = child.pdfViewer.pdfViewer?._pages;
         if (Array.isArray(pages)) {
             for (const pageView of pages) {
@@ -186,7 +496,6 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
         const widgetIdToFieldName = new Map<string, { name: string; type: PdfFormFieldType }>();
         let hasForms = false;
 
-        // 1) Field objects (best mapping to actual field names)
         const getFieldObjects = (doc as any).getFieldObjects;
         if (typeof getFieldObjects === 'function') {
             try {
@@ -223,7 +532,6 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
             }
         }
 
-        // 2) AnnotationStorage overrides (captures live edits)
         const annotationStorage = this.getAnnotationStorage(child);
         if (annotationStorage) {
             const all =
@@ -245,7 +553,6 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
             }
         }
 
-        // 3) DOM fallback (rendered pages only)
         const domRoot = child.pdfViewer.dom?.viewerEl;
         if (domRoot) {
             const controls = Array.from(domRoot.querySelectorAll<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>(
@@ -304,7 +611,6 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
 
     private normalizeFieldType(typeCode: unknown, fieldObject: any): PdfFormFieldType {
         const code = typeof typeCode === 'string' ? typeCode : '';
-        // PDF.js uses PDF field types (Tx, Btn, Ch, Sig) in many builds.
         if (code === 'Tx') return 'text';
         if (code === 'Ch') {
             const isCombo = !!fieldObject?.combo;
@@ -312,10 +618,8 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
         }
         if (code === 'Sig') return 'unknown';
         if (code === 'Btn') {
-            // Disambiguate checkbox vs radio if possible.
             if (fieldObject?.radioButton) return 'radio';
             if (fieldObject?.checkBox) return 'checkbox';
-            // Some builds use `buttonType`.
             const bt = String(fieldObject?.buttonType ?? '').toLowerCase();
             if (bt.includes('radio')) return 'radio';
             if (bt.includes('check')) return 'checkbox';
@@ -334,26 +638,51 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
         if (el instanceof HTMLTextAreaElement) {
             return { type: 'text', value: el.value ?? '' };
         }
-        // HTMLSelectElement
         if (el.multiple) {
             return { type: 'option-list', value: Array.from(el.selectedOptions).map((o) => o.value) };
         }
         return { type: 'dropdown', value: el.value ?? '' };
     }
 
-    /**
-     * Save current form field values into the underlying PDF file (without flattening).
-     */
+    // --- Form locking (prevent edits during save) ---
+
+    private setFormFieldsLocked(child: PDFViewerChild, locked: boolean) {
+        const viewerEl = child.pdfViewer?.dom?.viewerEl;
+        if (!viewerEl) return;
+
+        const controls = viewerEl.querySelectorAll<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>(
+            '.annotationLayer input, .annotationLayer textarea, .annotationLayer select',
+        );
+        for (const el of controls) {
+            if (locked) {
+                if (!el.hasAttribute('data-pdf-plus-was-disabled')) {
+                    el.setAttribute('data-pdf-plus-was-disabled', el.disabled ? 'true' : 'false');
+                }
+                el.disabled = true;
+            } else {
+                const wasDisabled = el.getAttribute('data-pdf-plus-was-disabled');
+                if (wasDisabled !== null) {
+                    el.disabled = wasDisabled === 'true';
+                    el.removeAttribute('data-pdf-plus-was-disabled');
+                }
+            }
+        }
+    }
+
+    // --- Save pipeline ---
+
     async saveFormFields(child: PDFViewerChild, options?: { silent?: boolean }): Promise<boolean> {
+        const silent = options?.silent ?? false;
+
         if (!this.isEnabled()) {
-            if (!options?.silent) {
+            if (!silent) {
                 new Notice(`${this.plugin.manifest.name}: Enable PDF editing to save form fields.`);
             }
             return false;
         }
 
         if (!this.lib.isEditable(child)) {
-            if (!options?.silent) {
+            if (!silent) {
                 new Notice(`${this.plugin.manifest.name}: This PDF cannot be edited (e.g. external file or PDF editing disabled).`);
             }
             return false;
@@ -363,42 +692,77 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
         if (!(file instanceof TFile)) return false;
 
         const state = this.getState(child);
+        if (!silent && state.timerId !== null) {
+            window.clearTimeout(state.timerId);
+            state.timerId = null;
+        }
         if (state.inFlight) {
             state.queued = true;
+            state.queuedSilent = state.queuedSilent && silent;
+            if (!silent) {
+                new Notice(`${this.plugin.manifest.name}: Save queued...`);
+            }
             return true;
         }
 
         state.inFlight = true;
+        this.notifyListeners(child, 0);
+
         try {
+            // Phase 1: Collect form state (re-collect as late as possible to capture recent edits)
+            this.notifyListeners(child, 5);
             const collected = await this.collectFormState(child);
             if (!collected.hasForms || collected.fields.size === 0) {
-                if (!options?.silent) {
+                if (!silent) {
                     new Notice(`${this.plugin.manifest.name}: No form fields found in this PDF.`);
                 }
                 state.dirty = false;
+                this.notifyListeners(child, 100);
                 return false;
             }
 
-            await this.writeFormStateToFile(file, collected.fields);
+            // Lock form fields so the user can't edit during the write cycle.
+            this.setFormFieldsLocked(child, true);
+
+            // Phase 2: Load PDF document (or use cache)
+            this.notifyListeners(child, 15);
+            const pdfDoc = await this.getOrLoadPdfDoc(file);
+
+            // Phase 3: Apply form values
+            this.notifyListeners(child, 35);
+            await this.applyFormStateToPdfLibDocument(pdfDoc, collected.fields);
+
+            // Phase 4: Serialize PDF
+            this.notifyListeners(child, 55);
+            const buffer = await pdfDoc.save();
+
+            // Phase 5: Write to vault
+            this.notifyListeners(child, 80);
+            await this.app.vault.modifyBinary(file, buffer);
+
+            // Cache the PDFDocument for next save
+            this.cachePdfDoc(file, pdfDoc);
 
             state.dirty = false;
-            if (!options?.silent) {
+            this.notifyListeners(child, 100);
+            if (!silent) {
                 new Notice(`${this.plugin.manifest.name}: Saved PDF form fields.`);
             }
             return true;
         } finally {
+            this.setFormFieldsLocked(child, false);
             state.inFlight = false;
             const shouldRunAgain = state.queued;
+            const queuedSilent = state.queuedSilent;
             state.queued = false;
+            state.queuedSilent = true;
+            this.notifyListeners(child, 0);
             if (shouldRunAgain) {
-                this.saveFormFields(child, { silent: true }).catch((e) => console.error(e));
+                this.saveFormFields(child, { silent: queuedSilent }).catch((e) => console.error(e));
             }
         }
     }
 
-    /**
-     * Called when a PDF viewer is unloading. If auto-save is enabled and forms are dirty, try a final save.
-     */
     onChildUnload(child: PDFViewerChild) {
         const state = this.getState(child);
         if (state.timerId !== null) {
@@ -409,12 +773,16 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
         if (this.isAutoSaveEnabled() && state.dirty) {
             this.saveFormFields(child, { silent: true }).catch((e) => console.error(e));
         }
+
+        this.stateListeners.delete(child);
     }
 
     private async writeFormStateToFile(file: TFile, fields: Map<string, CollectedPdfFormFieldState>) {
-        const pdfDoc = await this.lib.loadPdfLibDocument(file);
+        const pdfDoc = await this.getOrLoadPdfDoc(file);
         await this.applyFormStateToPdfLibDocument(pdfDoc, fields);
-        await this.app.vault.modifyBinary(file, await pdfDoc.save());
+        const buffer = await pdfDoc.save();
+        await this.app.vault.modifyBinary(file, buffer);
+        this.cachePdfDoc(file, pdfDoc);
     }
 
     private async applyFormStateToPdfLibDocument(pdfDoc: PDFDocument, fields: Map<string, CollectedPdfFormFieldState>) {
@@ -440,7 +808,6 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
             this.applyValueToPdfLibField(field, state);
         }
 
-        // Best-effort: ensure appearances are up-to-date but do not flatten.
         if (typeof form.updateFieldAppearances === 'function') {
             try {
                 await form.updateFieldAppearances();
@@ -453,7 +820,6 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
     private applyValueToPdfLibField(field: any, state: CollectedPdfFormFieldState) {
         const value = state.value;
 
-        // Prefer type-guided updates first, then fall back to “duck-typed” methods.
         switch (state.type) {
             case 'checkbox': {
                 const bool = value === true || value === 'true' || value === 'Yes' || value === 'On' || value === '1';
@@ -491,7 +857,6 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
                 break;
         }
 
-        // Fallback: attempt common operations.
         if (typeof field.setText === 'function') {
             field.setText(value === null ? '' : String(value));
             return;
@@ -510,4 +875,3 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
         }
     }
 }
-

--- a/src/lib/forms/index.ts
+++ b/src/lib/forms/index.ts
@@ -1,0 +1,513 @@
+import { Notice, TFile } from 'obsidian';
+
+import { PDFDocument } from '@cantoo/pdf-lib';
+
+import PDFPlus from 'main';
+import { PDFPlusLibSubmodule } from 'lib/submodule';
+import { PDFViewerChild } from 'typings';
+
+export type PdfFormFieldValue = string | string[] | boolean | null;
+
+export type PdfFormFieldType =
+    | 'text'
+    | 'checkbox'
+    | 'radio'
+    | 'dropdown'
+    | 'option-list'
+    | 'unknown';
+
+export type PdfFormFieldValueSource = 'fieldObjects' | 'annotationStorage' | 'dom';
+
+export interface CollectedPdfFormFieldState {
+    name: string;
+    type: PdfFormFieldType;
+    value: PdfFormFieldValue;
+    source: PdfFormFieldValueSource;
+}
+
+export interface CollectedPdfFormState {
+    /** Whether the PDF appears to contain interactive form fields. */
+    hasForms: boolean;
+    /** Field state keyed by the PDF field name. */
+    fields: Map<string, CollectedPdfFormFieldState>;
+}
+
+type ChildSaveState = {
+    dirty: boolean;
+    inFlight: boolean;
+    queued: boolean;
+    timerId: number | null;
+};
+
+function isRecord(value: unknown): value is Record<string, any> {
+    return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeStorageEntries(all: unknown): Array<[string, any]> {
+    if (!all) return [];
+    if (all instanceof Map) {
+        return Array.from(all.entries()).map(([k, v]) => [String(k), v]);
+    }
+    if (Array.isArray(all)) {
+        return all
+            .filter((entry) => Array.isArray(entry) && entry.length >= 2)
+            .map((entry) => [String(entry[0]), entry[1]]);
+    }
+    if (isRecord(all)) {
+        return Object.entries(all).map(([k, v]) => [k, v]);
+    }
+    return [];
+}
+
+function extractAnnotationStorageValue(value: any): unknown {
+    if (value === null || value === undefined) return null;
+    if (!isRecord(value)) return value;
+    if ('value' in value) return value.value;
+    if ('formattedValue' in value) return value.formattedValue;
+    if ('valueAsString' in value) return value.valueAsString;
+    return value;
+}
+
+function coerceToFieldValue(value: unknown): PdfFormFieldValue {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'string') return value;
+    if (typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return value.map((v) => String(v));
+    if (typeof value === 'number') return String(value);
+    return String(value);
+}
+
+export class PdfFormsLib extends PDFPlusLibSubmodule {
+    private childState = new WeakMap<PDFViewerChild, ChildSaveState>();
+
+    constructor(plugin: PDFPlus) {
+        super(plugin);
+    }
+
+    private getState(child: PDFViewerChild): ChildSaveState {
+        let state = this.childState.get(child);
+        if (!state) {
+            state = { dirty: false, inFlight: false, queued: false, timerId: null };
+            this.childState.set(child, state);
+        }
+        return state;
+    }
+
+    isEnabled() {
+        // This feature is a subset of “editing PDF files”, so keep it behind the same safety gate.
+        return this.plugin.settings.enablePDFEdit && this.plugin.settings.enablePdfFormSave;
+    }
+
+    isAutoSaveEnabled() {
+        return this.isEnabled() && this.plugin.settings.autoSavePdfForms;
+    }
+
+    getAutoSaveDebounceMs() {
+        const ms = this.plugin.settings.autoSavePdfFormsDebounceMs;
+        return typeof ms === 'number' && Number.isFinite(ms) ? Math.max(0, ms) : 2000;
+    }
+
+    /**
+     * Register event listeners that mark the PDF forms as dirty and optionally auto-save.
+     * This should be called after the viewer DOM is ready.
+     */
+    registerFormChangeListeners(child: PDFViewerChild, viewerContainerEl: HTMLElement) {
+        if (!this.isEnabled()) return;
+
+        const handler = (evt: Event) => {
+            if (!(evt.target instanceof HTMLElement)) return;
+            if (!evt.target.closest('.annotationLayer')) return;
+            if (!evt.target.matches('input, textarea, select')) return;
+            this.markDirty(child);
+        };
+
+        // Capture phase so we see changes early and reliably.
+        child.component?.registerDomEvent(viewerContainerEl, 'input', handler, { capture: true });
+        child.component?.registerDomEvent(viewerContainerEl, 'change', handler, { capture: true });
+    }
+
+    markDirty(child: PDFViewerChild) {
+        const state = this.getState(child);
+        state.dirty = true;
+
+        if (!this.isAutoSaveEnabled()) return;
+
+        if (state.timerId !== null) {
+            window.clearTimeout(state.timerId);
+        }
+
+        state.timerId = window.setTimeout(() => {
+            state.timerId = null;
+            this.saveFormFields(child, { silent: true }).catch((e) => console.error(e));
+        }, this.getAutoSaveDebounceMs());
+    }
+
+    async hasForms(child: PDFViewerChild): Promise<boolean> {
+        const doc = child.pdfViewer.pdfViewer?.pdfDocument;
+        if (!doc) return false;
+
+        const getFieldObjects = (doc as any).getFieldObjects;
+        if (typeof getFieldObjects === 'function') {
+            try {
+                const fieldObjects = await getFieldObjects.call(doc);
+                if (isRecord(fieldObjects) && Object.keys(fieldObjects).length > 0) return true;
+            } catch {
+                // ignore
+            }
+        }
+
+        // Fallback: if any form control exists in rendered annotation layers, treat as forms present.
+        if (child.pdfViewer.dom?.viewerEl?.querySelector('.annotationLayer input, .annotationLayer textarea, .annotationLayer select')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private getAnnotationStorage(child: PDFViewerChild): any | null {
+        // Best-effort: Obsidian’s PDF.js may expose it in different places across versions.
+        const pages = child.pdfViewer.pdfViewer?._pages;
+        if (Array.isArray(pages)) {
+            for (const pageView of pages) {
+                const storage = pageView?.annotationLayer?.annotationStorage;
+                if (storage) return storage;
+            }
+        }
+        const maybeStorage = (child.pdfViewer.pdfViewer as any)?.annotationStorage;
+        return maybeStorage ?? null;
+    }
+
+    async collectFormState(child: PDFViewerChild): Promise<CollectedPdfFormState> {
+        const fields = new Map<string, CollectedPdfFormFieldState>();
+
+        const doc = child.pdfViewer.pdfViewer?.pdfDocument;
+        if (!doc) return { hasForms: false, fields };
+
+        const widgetIdToFieldName = new Map<string, { name: string; type: PdfFormFieldType }>();
+        let hasForms = false;
+
+        // 1) Field objects (best mapping to actual field names)
+        const getFieldObjects = (doc as any).getFieldObjects;
+        if (typeof getFieldObjects === 'function') {
+            try {
+                const fieldObjects = await getFieldObjects.call(doc);
+                if (isRecord(fieldObjects) && Object.keys(fieldObjects).length > 0) {
+                    hasForms = true;
+                    for (const [fieldName, widgets] of Object.entries(fieldObjects)) {
+                        const first = Array.isArray(widgets) ? widgets[0] : null;
+                        const fieldTypeCode = first?.type ?? first?.fieldType ?? first?.fieldTypeCode ?? null;
+                        const type = this.normalizeFieldType(fieldTypeCode, first);
+
+                        if (!fields.has(fieldName)) {
+                            const value = coerceToFieldValue(first?.value);
+                            fields.set(fieldName, {
+                                name: fieldName,
+                                type,
+                                value,
+                                source: 'fieldObjects',
+                            });
+                        }
+
+                        if (Array.isArray(widgets)) {
+                            for (const w of widgets) {
+                                const id = w?.id;
+                                if (typeof id === 'string' && id) {
+                                    widgetIdToFieldName.set(id, { name: fieldName, type });
+                                }
+                            }
+                        }
+                    }
+                }
+            } catch {
+                // ignore
+            }
+        }
+
+        // 2) AnnotationStorage overrides (captures live edits)
+        const annotationStorage = this.getAnnotationStorage(child);
+        if (annotationStorage) {
+            const all =
+                typeof annotationStorage.getAll === 'function'
+                    ? annotationStorage.getAll()
+                    : (annotationStorage.all ?? annotationStorage.storage ?? annotationStorage.serializable ?? null);
+
+            for (const [widgetId, raw] of normalizeStorageEntries(all)) {
+                const mapped = widgetIdToFieldName.get(widgetId);
+                if (!mapped) continue;
+
+                const value = coerceToFieldValue(extractAnnotationStorageValue(raw));
+                fields.set(mapped.name, {
+                    name: mapped.name,
+                    type: mapped.type,
+                    value,
+                    source: 'annotationStorage',
+                });
+            }
+        }
+
+        // 3) DOM fallback (rendered pages only)
+        const domRoot = child.pdfViewer.dom?.viewerEl;
+        if (domRoot) {
+            const controls = Array.from(domRoot.querySelectorAll<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>(
+                '.annotationLayer input, .annotationLayer textarea, .annotationLayer select'
+            ));
+            if (controls.length > 0) hasForms = true;
+
+            const radioSelections = new Map<string, string>();
+
+            for (const el of controls) {
+                const tag = el.tagName.toLowerCase();
+                const typeAttr = (el instanceof HTMLInputElement ? el.type : '').toLowerCase();
+
+                const section = el.closest<HTMLElement>('section[data-annotation-id]');
+                const widgetId = section?.dataset?.annotationId;
+                const mapped = widgetId ? widgetIdToFieldName.get(widgetId) : null;
+
+                const name =
+                    (el.getAttribute('name') && el.getAttribute('name')!.trim()) ||
+                    (mapped?.name ?? null) ||
+                    (el.getAttribute('data-field-name') && el.getAttribute('data-field-name')!.trim()) ||
+                    null;
+                if (!name) continue;
+
+                if (tag === 'input' && typeAttr === 'radio') {
+                    const input = el as HTMLInputElement;
+                    if (input.checked) {
+                        radioSelections.set(name, input.value ?? 'true');
+                    }
+                    continue;
+                }
+
+                const { type, value } = this.extractDomValue(el);
+                if (value === null && value !== false && value !== '') continue;
+
+                fields.set(name, {
+                    name,
+                    type: mapped?.type ?? type,
+                    value,
+                    source: 'dom',
+                });
+            }
+
+            for (const [name, value] of radioSelections.entries()) {
+                fields.set(name, {
+                    name,
+                    type: 'radio',
+                    value,
+                    source: 'dom',
+                });
+            }
+        }
+
+        return { hasForms, fields };
+    }
+
+    private normalizeFieldType(typeCode: unknown, fieldObject: any): PdfFormFieldType {
+        const code = typeof typeCode === 'string' ? typeCode : '';
+        // PDF.js uses PDF field types (Tx, Btn, Ch, Sig) in many builds.
+        if (code === 'Tx') return 'text';
+        if (code === 'Ch') {
+            const isCombo = !!fieldObject?.combo;
+            return isCombo ? 'dropdown' : 'option-list';
+        }
+        if (code === 'Sig') return 'unknown';
+        if (code === 'Btn') {
+            // Disambiguate checkbox vs radio if possible.
+            if (fieldObject?.radioButton) return 'radio';
+            if (fieldObject?.checkBox) return 'checkbox';
+            // Some builds use `buttonType`.
+            const bt = String(fieldObject?.buttonType ?? '').toLowerCase();
+            if (bt.includes('radio')) return 'radio';
+            if (bt.includes('check')) return 'checkbox';
+            return 'checkbox';
+        }
+        return 'unknown';
+    }
+
+    private extractDomValue(el: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement): { type: PdfFormFieldType; value: PdfFormFieldValue } {
+        if (el instanceof HTMLInputElement) {
+            const type = el.type.toLowerCase();
+            if (type === 'checkbox') return { type: 'checkbox', value: !!el.checked };
+            if (type === 'radio') return { type: 'radio', value: el.checked ? (el.value ?? 'true') : null };
+            return { type: 'text', value: el.value ?? '' };
+        }
+        if (el instanceof HTMLTextAreaElement) {
+            return { type: 'text', value: el.value ?? '' };
+        }
+        // HTMLSelectElement
+        if (el.multiple) {
+            return { type: 'option-list', value: Array.from(el.selectedOptions).map((o) => o.value) };
+        }
+        return { type: 'dropdown', value: el.value ?? '' };
+    }
+
+    /**
+     * Save current form field values into the underlying PDF file (without flattening).
+     */
+    async saveFormFields(child: PDFViewerChild, options?: { silent?: boolean }): Promise<boolean> {
+        if (!this.isEnabled()) {
+            if (!options?.silent) {
+                new Notice(`${this.plugin.manifest.name}: Enable PDF editing to save form fields.`);
+            }
+            return false;
+        }
+
+        if (!this.lib.isEditable(child)) {
+            if (!options?.silent) {
+                new Notice(`${this.plugin.manifest.name}: This PDF cannot be edited (e.g. external file or PDF editing disabled).`);
+            }
+            return false;
+        }
+
+        const file = child.file;
+        if (!(file instanceof TFile)) return false;
+
+        const state = this.getState(child);
+        if (state.inFlight) {
+            state.queued = true;
+            return true;
+        }
+
+        state.inFlight = true;
+        try {
+            const collected = await this.collectFormState(child);
+            if (!collected.hasForms || collected.fields.size === 0) {
+                if (!options?.silent) {
+                    new Notice(`${this.plugin.manifest.name}: No form fields found in this PDF.`);
+                }
+                state.dirty = false;
+                return false;
+            }
+
+            await this.writeFormStateToFile(file, collected.fields);
+
+            state.dirty = false;
+            if (!options?.silent) {
+                new Notice(`${this.plugin.manifest.name}: Saved PDF form fields.`);
+            }
+            return true;
+        } finally {
+            state.inFlight = false;
+            const shouldRunAgain = state.queued;
+            state.queued = false;
+            if (shouldRunAgain) {
+                this.saveFormFields(child, { silent: true }).catch((e) => console.error(e));
+            }
+        }
+    }
+
+    /**
+     * Called when a PDF viewer is unloading. If auto-save is enabled and forms are dirty, try a final save.
+     */
+    onChildUnload(child: PDFViewerChild) {
+        const state = this.getState(child);
+        if (state.timerId !== null) {
+            window.clearTimeout(state.timerId);
+            state.timerId = null;
+        }
+
+        if (this.isAutoSaveEnabled() && state.dirty) {
+            this.saveFormFields(child, { silent: true }).catch((e) => console.error(e));
+        }
+    }
+
+    private async writeFormStateToFile(file: TFile, fields: Map<string, CollectedPdfFormFieldState>) {
+        const pdfDoc = await this.lib.loadPdfLibDocument(file);
+        await this.applyFormStateToPdfLibDocument(pdfDoc, fields);
+        await this.app.vault.modifyBinary(file, await pdfDoc.save());
+    }
+
+    private async applyFormStateToPdfLibDocument(pdfDoc: PDFDocument, fields: Map<string, CollectedPdfFormFieldState>) {
+        const form = (pdfDoc as any).getForm?.();
+        if (!form) {
+            throw new Error('pdf-lib form API not available');
+        }
+
+        const pdfLibFields: any[] = typeof form.getFields === 'function' ? form.getFields() : [];
+        const byName = new Map<string, any>();
+        for (const f of pdfLibFields) {
+            try {
+                const name = typeof f.getName === 'function' ? f.getName() : null;
+                if (typeof name === 'string') byName.set(name, f);
+            } catch {
+                // ignore
+            }
+        }
+
+        for (const [name, state] of fields.entries()) {
+            const field = byName.get(name);
+            if (!field) continue;
+            this.applyValueToPdfLibField(field, state);
+        }
+
+        // Best-effort: ensure appearances are up-to-date but do not flatten.
+        if (typeof form.updateFieldAppearances === 'function') {
+            try {
+                await form.updateFieldAppearances();
+            } catch {
+                // ignore
+            }
+        }
+    }
+
+    private applyValueToPdfLibField(field: any, state: CollectedPdfFormFieldState) {
+        const value = state.value;
+
+        // Prefer type-guided updates first, then fall back to “duck-typed” methods.
+        switch (state.type) {
+            case 'checkbox': {
+                const bool = value === true || value === 'true' || value === 'Yes' || value === 'On' || value === '1';
+                if (typeof field.check === 'function' && typeof field.uncheck === 'function') {
+                    bool ? field.check() : field.uncheck();
+                    return;
+                }
+                break;
+            }
+            case 'radio':
+            case 'dropdown':
+            case 'option-list': {
+                if (typeof field.select === 'function') {
+                    try {
+                        if (Array.isArray(value)) {
+                            field.select(value);
+                        } else if (value !== null) {
+                            field.select(String(value));
+                        }
+                        return;
+                    } catch {
+                        // ignore and fall through
+                    }
+                }
+                break;
+            }
+            case 'text': {
+                if (typeof field.setText === 'function') {
+                    field.setText(value === null ? '' : String(value));
+                    return;
+                }
+                break;
+            }
+            case 'unknown':
+                break;
+        }
+
+        // Fallback: attempt common operations.
+        if (typeof field.setText === 'function') {
+            field.setText(value === null ? '' : String(value));
+            return;
+        }
+        if (typeof field.select === 'function' && value !== null) {
+            try {
+                Array.isArray(value) ? field.select(value) : field.select(String(value));
+                return;
+            } catch {
+                // ignore
+            }
+        }
+        if (typeof field.check === 'function' && typeof field.uncheck === 'function') {
+            const bool = !!value && value !== 'false' && value !== 'Off' && value !== '0';
+            bool ? field.check() : field.uncheck();
+        }
+    }
+}
+

--- a/src/lib/forms/index.ts
+++ b/src/lib/forms/index.ts
@@ -1,4 +1,4 @@
-import { Notice, TFile } from 'obsidian';
+import { Modal, Notice, TFile, setIcon } from 'obsidian';
 
 import { PDFDocument } from '@cantoo/pdf-lib';
 
@@ -40,11 +40,17 @@ type ChildSaveState = {
     queued: boolean;
     queuedSilent: boolean;
     timerId: number | null;
+    disposed: boolean;
 };
 
 type CachedPdfDoc = {
     pdfDoc: PDFDocument;
-    writeMtime: number;
+    freshness: FileFreshness;
+};
+
+type FileFreshness = {
+    mtime: number;
+    size: number;
 };
 
 type PDFDocumentLike = {
@@ -90,6 +96,11 @@ function coerceToFieldValue(value: unknown): PdfFormFieldValue {
 }
 
 export class PdfFormsLib extends PDFPlusLibSubmodule {
+    private readonly closeSaveModalOptions = {
+        title: 'Saving PDF form fields',
+        message: 'Saving changes before closing...',
+    };
+
     private childState = new WeakMap<PDFViewerChild, ChildSaveState>();
     private autoFitRegistered = new WeakSet<PDFViewerChild>();
     private autoFitRafByEl = new WeakMap<HTMLElement, number>();
@@ -101,15 +112,43 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
 
     constructor(plugin: PDFPlus) {
         super(plugin);
+        this.plugin.registerEvent(this.app.vault.on('modify', (file) => {
+            if (!(file instanceof TFile) || file.extension !== 'pdf') return;
+            this.invalidatePdfDocCache(file.path);
+        }));
+        this.plugin.registerEvent(this.app.vault.on('delete', (file) => {
+            if (!(file instanceof TFile) || file.extension !== 'pdf') return;
+            this.invalidatePdfDocCache(file.path);
+        }));
+        this.plugin.registerEvent(this.app.vault.on('rename', (file, oldPath) => {
+            if (!(file instanceof TFile) || file.extension !== 'pdf') return;
+            this.invalidatePdfDocCache(oldPath);
+            this.invalidatePdfDocCache(file.path);
+        }));
+    }
+
+    private getFileFreshness(file: TFile): FileFreshness {
+        return { mtime: file.stat.mtime, size: file.stat.size };
+    }
+
+    private isFreshnessEqual(a: FileFreshness, b: FileFreshness): boolean {
+        return a.mtime === b.mtime && a.size === b.size;
     }
 
     private getState(child: PDFViewerChild): ChildSaveState {
         let state = this.childState.get(child);
         if (!state) {
-            state = { dirty: false, inFlight: false, queued: false, queuedSilent: true, timerId: null };
+            state = { dirty: false, inFlight: false, queued: false, queuedSilent: true, timerId: null, disposed: false };
             this.childState.set(child, state);
         }
         return state;
+    }
+
+    private isChildUsableForSave(child: PDFViewerChild, state?: ChildSaveState): boolean {
+        const saveState = state ?? this.getState(child);
+        if (saveState.disposed) return false;
+        if ((child as any).unloaded) return false;
+        return child.file instanceof TFile;
     }
 
     isEnabled() {
@@ -137,6 +176,149 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
         return this.getState(child).inFlight;
     }
 
+    shouldConfirmUnsavedOnClose(): boolean {
+        return !!this.plugin.settings.confirmUnsavedPdfFormsOnClose;
+    }
+
+    async handlePendingFormChangesBeforeClose(child: PDFViewerChild): Promise<boolean> {
+        if (!this.shouldConfirmUnsavedOnClose()) return true;
+        if (!this.isEnabled()) return true;
+        if (!this.isDirty(child)) return true;
+
+        if (this.isAutoSaveEnabled()) {
+            return await this.waitForSaveWithModal(child, this.closeSaveModalOptions);
+        }
+
+        const action = await this.showUnsavedChangesPromptModal();
+        if (action === 'cancel') return false;
+        if (action === 'discard') return true;
+
+        return await this.waitForSaveWithModal(child, this.closeSaveModalOptions);
+    }
+
+    private async showUnsavedChangesPromptModal(): Promise<'save' | 'discard' | 'cancel'> {
+        return await new Promise((resolve) => {
+            let decided = false;
+            const done = (value: 'save' | 'discard' | 'cancel') => {
+                if (decided) return;
+                decided = true;
+                resolve(value);
+                modal.close();
+            };
+
+            const modal = new Modal(this.app);
+            const onClose = modal.onClose.bind(modal);
+            modal.onOpen = () => {
+                modal.titleEl.setText('Unsaved PDF form changes');
+                modal.contentEl.empty();
+                modal.contentEl.createEl('p', {
+                    text: 'Save form changes before closing this PDF?',
+                    cls: 'pdf-plus-form-save-confirm-text',
+                });
+
+                const actionsEl = modal.contentEl.createDiv('pdf-plus-form-save-confirm-actions');
+                actionsEl.createEl('button', { text: 'Save', cls: 'mod-cta' })
+                    .addEventListener('click', () => done('save'));
+                actionsEl.createEl('button', { text: 'Don\'t save' })
+                    .addEventListener('click', () => done('discard'));
+                actionsEl.createEl('button', { text: 'Cancel' })
+                    .addEventListener('click', () => done('cancel'));
+            };
+            modal.onClose = () => {
+                onClose();
+                if (!decided) {
+                    decided = true;
+                    resolve('cancel');
+                }
+            };
+            modal.open();
+        });
+    }
+
+    private async waitForSaveWithModal(
+        child: PDFViewerChild,
+        options: { title: string; message: string },
+    ): Promise<boolean> {
+        if (!this.isDirty(child) && !this.isSaving(child)) return true;
+
+        return await new Promise((resolve) => {
+            let settled = false;
+            let cancelled = false;
+            let progressEl: HTMLElement | null = null;
+
+            const finish = (ok: boolean) => {
+                if (settled) return;
+                settled = true;
+                unregister?.();
+                resolve(ok);
+                modal.close();
+            };
+
+            const updateProgress = (progress: number) => {
+                if (!progressEl) return;
+                const pct = Math.min(99, Math.max(0, Math.round(progress)));
+                progressEl.setText(`Saving... ${pct}%`);
+            };
+
+            const modal = new Modal(this.app);
+            const onClose = modal.onClose.bind(modal);
+            modal.onOpen = () => {
+                modal.titleEl.setText(options.title);
+                modal.contentEl.empty();
+
+                const row = modal.contentEl.createDiv('pdf-plus-form-save-wait-row');
+                const spinnerEl = row.createDiv('pdf-plus-form-save-wait-spinner');
+                setIcon(spinnerEl, 'lucide-loader-circle');
+                spinnerEl.addClass('is-spinning');
+
+                progressEl = row.createDiv('pdf-plus-form-save-wait-message');
+                progressEl.setText(options.message);
+
+                const actionsEl = modal.contentEl.createDiv('pdf-plus-form-save-confirm-actions');
+                actionsEl.createEl('button', { text: 'Cancel' }).addEventListener('click', () => {
+                    cancelled = true;
+                    finish(false);
+                });
+            };
+            modal.onClose = () => {
+                onClose();
+                if (!settled) {
+                    settled = true;
+                    unregister?.();
+                    resolve(false);
+                }
+            };
+
+            const unregister = this.registerStateListener(child, ({ dirty, saving, progress }) => {
+                updateProgress(progress);
+                if (!cancelled && !dirty && !saving) {
+                    finish(true);
+                }
+            });
+
+            modal.open();
+
+            const canStartSave = this.isDirty(child) && !this.isSaving(child);
+            if (canStartSave) {
+                const savePromise = this.saveFormFields(child, { silent: true });
+                savePromise.then((ok) => {
+                    if (!ok && this.isDirty(child) && !settled) {
+                        new Notice(`${this.plugin.manifest.name}: Failed to save PDF form fields.`);
+                        finish(false);
+                    }
+                }).catch((e) => {
+                    console.error(e);
+                    if (!settled) {
+                        new Notice(`${this.plugin.manifest.name}: Failed to save PDF form fields.`);
+                        finish(false);
+                    }
+                });
+            } else if (!this.isDirty(child) && !this.isSaving(child)) {
+                finish(true);
+            }
+        });
+    }
+
     registerStateListener(child: PDFViewerChild, cb: FormSaveStateListener): () => void {
         let listeners = this.stateListeners.get(child);
         if (!listeners) {
@@ -161,16 +343,17 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
 
     private async getOrLoadPdfDoc(file: TFile): Promise<PDFDocument> {
         const cached = this.pdfDocCache.get(file.path);
-        if (cached && file.stat.mtime === cached.writeMtime) {
+        const currentFreshness = this.getFileFreshness(file);
+        if (cached && this.isFreshnessEqual(currentFreshness, cached.freshness)) {
             return cached.pdfDoc;
         }
-        const pdfDoc = await this.lib.loadPdfLibDocument(file);
         this.pdfDocCache.delete(file.path);
+        const pdfDoc = await this.lib.loadPdfLibDocument(file);
         return pdfDoc;
     }
 
     private cachePdfDoc(file: TFile, pdfDoc: PDFDocument) {
-        this.pdfDocCache.set(file.path, { pdfDoc, writeMtime: file.stat.mtime });
+        this.pdfDocCache.set(file.path, { pdfDoc, freshness: this.getFileFreshness(file) });
     }
 
     invalidatePdfDocCache(filePath: string) {
@@ -185,8 +368,10 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
 
         this.preloadingFiles.add(file.path);
         this.lib.loadPdfLibDocument(file).then((pdfDoc) => {
-            if (!this.pdfDocCache.has(file.path)) {
-                this.pdfDocCache.set(file.path, { pdfDoc, writeMtime: file.stat.mtime });
+            const currentFreshness = this.getFileFreshness(file);
+            const cached = this.pdfDocCache.get(file.path);
+            if (!cached || !this.isFreshnessEqual(cached.freshness, currentFreshness)) {
+                this.pdfDocCache.set(file.path, { pdfDoc, freshness: currentFreshness });
             }
         }).catch(() => {}).finally(() => {
             this.preloadingFiles.delete(file.path);
@@ -436,6 +621,7 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
 
     markDirty(child: PDFViewerChild) {
         const state = this.getState(child);
+        if (state.disposed) return;
         const wasDirty = state.dirty;
         state.dirty = true;
 
@@ -476,6 +662,9 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
     }
 
     private getAnnotationStorage(child: PDFViewerChild): any | null {
+        const viewerStorage = (child.pdfViewer.pdfViewer as any)?.annotationStorage;
+        if (viewerStorage) return viewerStorage;
+
         const pages = child.pdfViewer.pdfViewer?._pages;
         if (Array.isArray(pages)) {
             for (const pageView of pages) {
@@ -483,8 +672,26 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
                 if (storage) return storage;
             }
         }
-        const maybeStorage = (child.pdfViewer.pdfViewer as any)?.annotationStorage;
-        return maybeStorage ?? null;
+        return null;
+    }
+
+    private async flushPendingActiveFormEdit(child: PDFViewerChild) {
+        const viewerContainerEl = child.pdfViewer?.dom?.viewerContainerEl;
+        if (!viewerContainerEl) return;
+        const doc = viewerContainerEl.doc ?? viewerContainerEl.ownerDocument;
+        const activeEl = doc?.activeElement;
+        if (!(activeEl instanceof HTMLElement)) return;
+        if (!viewerContainerEl.contains(activeEl)) return;
+        if (!activeEl.closest('.annotationLayer')) return;
+        if (!activeEl.matches('input, textarea, select')) return;
+
+        // Some PDFs update annotation storage only after commit/blur.
+        activeEl.dispatchEvent(new Event('change', { bubbles: true }));
+        if (typeof (activeEl as any).blur === 'function') {
+            (activeEl as any).blur();
+        }
+
+        await new Promise<void>((resolve) => window.setTimeout(resolve, 0));
     }
 
     async collectFormState(child: PDFViewerChild): Promise<CollectedPdfFormState> {
@@ -507,21 +714,11 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
                         const fieldTypeCode = first?.type ?? first?.fieldType ?? first?.fieldTypeCode ?? null;
                         const type = this.normalizeFieldType(fieldTypeCode, first);
 
-                        if (!fields.has(fieldName)) {
-                            const value = coerceToFieldValue(first?.value);
-                            fields.set(fieldName, {
-                                name: fieldName,
-                                type,
-                                value,
-                                source: 'fieldObjects',
-                            });
-                        }
-
                         if (Array.isArray(widgets)) {
                             for (const w of widgets) {
                                 const id = w?.id;
-                                if (typeof id === 'string' && id) {
-                                    widgetIdToFieldName.set(id, { name: fieldName, type });
+                                if ((typeof id === 'string' || typeof id === 'number') && id !== '') {
+                                    widgetIdToFieldName.set(String(id), { name: fieldName, type });
                                 }
                             }
                         }
@@ -536,7 +733,7 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
         if (annotationStorage) {
             const all =
                 typeof annotationStorage.getAll === 'function'
-                    ? annotationStorage.getAll()
+                    ? await annotationStorage.getAll()
                     : (annotationStorage.all ?? annotationStorage.storage ?? annotationStorage.serializable ?? null);
 
             for (const [widgetId, raw] of normalizeStorageEntries(all)) {
@@ -673,6 +870,8 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
 
     async saveFormFields(child: PDFViewerChild, options?: { silent?: boolean }): Promise<boolean> {
         const silent = options?.silent ?? false;
+        const state = this.getState(child);
+        if (!this.isChildUsableForSave(child, state)) return false;
 
         if (!this.isEnabled()) {
             if (!silent) {
@@ -691,7 +890,6 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
         const file = child.file;
         if (!(file instanceof TFile)) return false;
 
-        const state = this.getState(child);
         if (!silent && state.timerId !== null) {
             window.clearTimeout(state.timerId);
             state.timerId = null;
@@ -709,15 +907,24 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
         this.notifyListeners(child, 0);
 
         try {
+            const sourceFreshness = this.getFileFreshness(file);
+
             // Phase 1: Collect form state (re-collect as late as possible to capture recent edits)
             this.notifyListeners(child, 5);
+            await this.flushPendingActiveFormEdit(child);
             const collected = await this.collectFormState(child);
-            if (!collected.hasForms || collected.fields.size === 0) {
+            if (!collected.hasForms) {
                 if (!silent) {
                     new Notice(`${this.plugin.manifest.name}: No form fields found in this PDF.`);
                 }
-                state.dirty = false;
-                this.notifyListeners(child, 100);
+                this.notifyListeners(child, 0);
+                return false;
+            }
+            if (collected.fields.size === 0) {
+                if (!silent) {
+                    new Notice(`${this.plugin.manifest.name}: Could not read form field values from the current viewer state. Try again after the page finishes rendering.`);
+                }
+                this.notifyListeners(child, 0);
                 return false;
             }
 
@@ -738,10 +945,23 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
 
             // Phase 5: Write to vault
             this.notifyListeners(child, 80);
+            const preWriteFreshness = this.getFileFreshness(file);
+            if (!this.isFreshnessEqual(preWriteFreshness, sourceFreshness)) {
+                this.invalidatePdfDocCache(file.path);
+                state.dirty = true;
+                this.notifyListeners(child, 0);
+                new Notice(`${this.plugin.manifest.name}: The PDF changed before form save completed. Save aborted to avoid overwriting newer content.`);
+                return false;
+            }
             await this.app.vault.modifyBinary(file, buffer);
 
             // Cache the PDFDocument for next save
-            this.cachePdfDoc(file, pdfDoc);
+            const latest = this.app.vault.getAbstractFileByPath(file.path);
+            if (latest instanceof TFile) {
+                this.cachePdfDoc(latest, pdfDoc);
+            } else {
+                this.invalidatePdfDocCache(file.path);
+            }
 
             state.dirty = false;
             this.notifyListeners(child, 100);
@@ -757,7 +977,7 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
             state.queued = false;
             state.queuedSilent = true;
             this.notifyListeners(child, 0);
-            if (shouldRunAgain) {
+            if (shouldRunAgain && this.isChildUsableForSave(child, state)) {
                 this.saveFormFields(child, { silent: queuedSilent }).catch((e) => console.error(e));
             }
         }
@@ -765,24 +985,15 @@ export class PdfFormsLib extends PDFPlusLibSubmodule {
 
     onChildUnload(child: PDFViewerChild) {
         const state = this.getState(child);
+        state.disposed = true;
         if (state.timerId !== null) {
             window.clearTimeout(state.timerId);
             state.timerId = null;
         }
-
-        if (this.isAutoSaveEnabled() && state.dirty) {
-            this.saveFormFields(child, { silent: true }).catch((e) => console.error(e));
-        }
+        state.queued = false;
+        state.queuedSilent = true;
 
         this.stateListeners.delete(child);
-    }
-
-    private async writeFormStateToFile(file: TFile, fields: Map<string, CollectedPdfFormFieldState>) {
-        const pdfDoc = await this.getOrLoadPdfDoc(file);
-        await this.applyFormStateToPdfLibDocument(pdfDoc, fields);
-        const buffer = await pdfDoc.save();
-        await this.app.vault.modifyBinary(file, buffer);
-        this.cachePdfDoc(file, pdfDoc);
     }
 
     private async applyFormStateToPdfLibDocument(pdfDoc: PDFDocument, fields: Map<string, CollectedPdfFormFieldState>) {

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -7,6 +7,7 @@ import PDFPlus from 'main';
 import { ColorPalette, ColorPaletteState } from 'color-palette';
 import { copyLinkLib } from './copy-link';
 import { HighlightLib } from './highlights';
+import { PdfFormsLib } from './forms';
 import { WorkspaceLib } from './workspace-lib';
 import { cropCanvas, encodeLinktext, getDirectPDFObj, isVersionNewerThan, parsePDFSubpath, removeExtension, rotateCanvas, toSingleLine, isTargetNode } from 'utils';
 import { PDFPlusCommands } from './commands';
@@ -47,6 +48,7 @@ export class PDFPlusLib {
     commands: PDFPlusCommands;
     copyLink: copyLinkLib;
     highlight: HighlightLib;
+    forms: PdfFormsLib;
     workspace: WorkspaceLib;
     composer: PDFComposer;
     dummyFileManager: DummyFileManager;
@@ -70,6 +72,7 @@ export class PDFPlusLib {
         this.commands = new PDFPlusCommands(plugin);
         this.copyLink = new copyLinkLib(plugin);
         this.highlight = new HighlightLib(plugin);
+        this.forms = new PdfFormsLib(plugin);
         this.workspace = new WorkspaceLib(plugin);
         this.composer = new PDFComposer(plugin);
         this.dummyFileManager = new DummyFileManager(plugin);
@@ -836,7 +839,10 @@ export class PDFPlusLib {
         return await this.loadPdfLibDocumentFromArrayBuffer(buffer);
     }
 
-    async loadPdfLibDocumentFromArrayBuffer(buffer: ArrayBuffer, readonly: boolean = false): Promise<PDFDocument> {
+    async loadPdfLibDocumentFromArrayBuffer(buffer: ArrayBuffer | Uint8Array, readonly: boolean = false): Promise<PDFDocument> {
+        if (buffer instanceof Uint8Array) {
+            buffer = buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength) as ArrayBuffer;
+        }
         try {
             return await PDFDocument.load(buffer, { ignoreEncryption: readonly });
         } catch (e) {

--- a/src/patchers/pdf-internals.ts
+++ b/src/patchers/pdf-internals.ts
@@ -237,6 +237,9 @@ const patchPDFViewerChild = (plugin: PDFPlus, child: PDFViewerChild) => {
                         viewerContainerEl.removeEventListener('pointerup', onPointerUp);
                         isModEvent = false;
                     };
+
+                    // Track form edits (and optionally auto-save) for form-fillable PDFs.
+                    plugin.lib.forms.registerFormChangeListeners(this, viewerContainerEl);
                 }
 
                 const addColorPaletteToToolbar = () => {
@@ -309,6 +312,7 @@ const patchPDFViewerChild = (plugin: PDFPlus, child: PDFViewerChild) => {
         },
         unload(old) {
             return function (this: PDFViewerChild) {
+                plugin.lib.forms.onChildUnload(this);
                 this.component?.unload();
                 return old.call(this);
             };

--- a/src/patchers/pdf-view.ts
+++ b/src/patchers/pdf-view.ts
@@ -16,6 +16,20 @@ export const patchPDFView = (plugin: PDFPlus): boolean => {
 
     if (!plugin.patchStatus.pdfView) {
         plugin.register(around(pdfView.constructor.prototype, {
+            save(old) {
+                return async function (this: PDFView, ...args: any[]) {
+                    const child = this.viewer?.child;
+                    if (child && plugin.settings.enablePdfFormSave && lib.isEditable(child)) {
+                        try {
+                            const saved = await lib.forms.saveFormFields(child, { silent: true });
+                            if (saved) return;
+                        } catch (e) {
+                            console.error(e);
+                        }
+                    }
+                    return old.call(this, ...args);
+                };
+            },
             getState(old) {
                 return function () {
                     const ret = old.call(this);

--- a/src/patchers/workspace.ts
+++ b/src/patchers/workspace.ts
@@ -1,4 +1,4 @@
-import { OpenViewState, PaneType, Workspace, parseLinktext, Platform } from 'obsidian';
+import { OpenViewState, PaneType, TFile, Workspace, WorkspaceLeaf, parseLinktext, Platform } from 'obsidian';
 import { around } from 'monkey-around';
 
 import PDFPlus from 'main';
@@ -8,6 +8,37 @@ import { focusObsidian } from 'utils';
 export const patchWorkspace = (plugin: PDFPlus) => {
     const app = plugin.app;
     const lib = plugin.lib;
+    const pendingUnsavedGuardByLeaf = new WeakMap<WorkspaceLeaf, Promise<boolean>>();
+
+    const guardUnsavedPdfFormChanges = async (leaf: WorkspaceLeaf, nextFilePath?: string | null) => {
+        const view = leaf.view;
+        if (!view || !lib.isPDFView(view)) return true;
+        const child = view.viewer?.child;
+        if (!child || !(child.file instanceof TFile)) return true;
+
+        if (nextFilePath && child.file.path === nextFilePath) {
+            return true;
+        }
+        return lib.forms.handlePendingFormChangesBeforeClose(child);
+    };
+    const guardUnsavedPdfFormChangesOnce = async (leaf: WorkspaceLeaf, nextFilePath?: string | null) => {
+        const existing = pendingUnsavedGuardByLeaf.get(leaf);
+        if (existing) return existing;
+        const promise = guardUnsavedPdfFormChanges(leaf, nextFilePath).finally(() => {
+            pendingUnsavedGuardByLeaf.delete(leaf);
+        });
+        pendingUnsavedGuardByLeaf.set(leaf, promise);
+        return promise;
+    };
+    const runWithUnsavedPdfFormGuard = async (
+        leaf: WorkspaceLeaf,
+        nextFilePath: string | null,
+        run: () => any,
+    ) => {
+        const proceed = await guardUnsavedPdfFormChangesOnce(leaf, nextFilePath);
+        if (!proceed) return;
+        return run();
+    };
 
     plugin.register(around(Workspace.prototype, {
         openLinkText(old) {
@@ -54,6 +85,35 @@ export const patchWorkspace = (plugin: PDFPlus) => {
                 return old.call(this, linktext, sourcePath, newLeaf, openViewState);
             };
         }
+    }));
+
+    // Intercept leaf file-open to guard unsaved PDF form edits.
+    plugin.register(around(WorkspaceLeaf.prototype, {
+        openFile(old) {
+            return async function (this: WorkspaceLeaf, file: TFile, openState?: any) {
+                return runWithUnsavedPdfFormGuard(this, file.path, () => old.call(this, file, openState));
+            };
+        },
+        setViewState(old) {
+            return async function (this: WorkspaceLeaf, viewState: any, eState?: any) {
+                const currentView = this.view;
+                const isCurrentPdf = !!currentView && lib.isPDFView(currentView);
+                if (isCurrentPdf) {
+                    const nextType = viewState?.type;
+                    const nextFilePath = typeof viewState?.state?.file === 'string' ? viewState.state.file : null;
+                    // Guard transitions that leave the currently opened PDF, including tab close.
+                    if (nextType !== 'pdf' || !nextFilePath || currentView.file?.path !== nextFilePath) {
+                        return runWithUnsavedPdfFormGuard(this, nextFilePath, () => old.call(this, viewState, eState));
+                    }
+                }
+                return old.call(this, viewState, eState);
+            };
+        },
+        detach(old) {
+            return async function (this: WorkspaceLeaf, ...args: any[]) {
+                return runWithUnsavedPdfFormGuard(this, null, () => old.apply(this, args));
+            };
+        },
     }));
 
     plugin.patchStatus.workspace = true;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -158,6 +158,8 @@ export interface PDFPlusSettings {
 	autoSavePdfForms: boolean;
 	/** Debounce interval for auto-saving form fields (ms). */
 	autoSavePdfFormsDebounceMs: number;
+	/** Warn or block when closing/switching away with unsaved PDF form edits. */
+	confirmUnsavedPdfFormsOnClose: boolean;
 	author: string;
 	writeHighlightToFileOpacity: number;
 	defaultWriteFileToggle: boolean;
@@ -436,6 +438,7 @@ export const DEFAULT_SETTINGS: PDFPlusSettings = {
 	enablePdfFormSave: true,
 	autoSavePdfForms: false,
 	autoSavePdfFormsDebounceMs: 2000,
+	confirmUnsavedPdfFormsOnClose: true,
 	author: '',
 	writeHighlightToFileOpacity: 0.2,
 	defaultWriteFileToggle: false,
@@ -1680,6 +1683,10 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 						.setName('Auto-save debounce (ms)')
 						.setDesc('How long to wait after the last form edit before saving.');
 				}
+
+				this.addToggleSetting('confirmUnsavedPdfFormsOnClose')
+					.setName('Confirm unsaved form edits when closing PDF')
+					.setDesc('When leaving a PDF with unsaved form edits, show a prompt. If auto-save is enabled, PDF++ will show a blocking “Saving...” dialog until save completes (or you cancel leaving).');
 			}
 			// this.addToggleSetting('enableEditEncryptedPDF')
 			// .setName('Enable editing encrypted PDF files');

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -152,6 +152,12 @@ export interface PDFPlusSettings {
 	alwaysRecordHistory: boolean;
 	renderMarkdownInStickyNote: boolean;
 	enablePDFEdit: boolean;
+	/** Enable saving form field values into PDFs (requires PDF editing enabled). */
+	enablePdfFormSave: boolean;
+	/** Auto-save PDF form fields after changes (debounced). */
+	autoSavePdfForms: boolean;
+	/** Debounce interval for auto-saving form fields (ms). */
+	autoSavePdfFormsDebounceMs: number;
 	author: string;
 	writeHighlightToFileOpacity: number;
 	defaultWriteFileToggle: boolean;
@@ -427,6 +433,9 @@ export const DEFAULT_SETTINGS: PDFPlusSettings = {
 	alwaysRecordHistory: true,
 	renderMarkdownInStickyNote: false,
 	enablePDFEdit: false,
+	enablePdfFormSave: true,
+	autoSavePdfForms: false,
+	autoSavePdfFormsDebounceMs: 2000,
 	author: '',
 	writeHighlightToFileOpacity: 0.2,
 	defaultWriteFileToggle: false,
@@ -1656,6 +1665,22 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 					const inputEl = (setting.components[0] as TextComponent).inputEl;
 					inputEl.toggleClass('error', !inputEl.value);
 				});
+
+			this.addToggleSetting('enablePdfFormSave', () => this.redisplay())
+				.setName('Enable saving PDF form fields')
+				.setDesc('Persist edits in form-fillable PDFs by writing form field values back into the PDF file (without flattening).');
+
+			if (this.plugin.settings.enablePdfFormSave) {
+				this.addToggleSetting('autoSavePdfForms', () => this.redisplay())
+					.setName('Auto-save PDF form fields')
+					.setDesc('When enabled, PDF++ will automatically save form changes after a short delay.');
+
+				if (this.plugin.settings.autoSavePdfForms) {
+					this.addNumberSetting('autoSavePdfFormsDebounceMs')
+						.setName('Auto-save debounce (ms)')
+						.setDesc('How long to wait after the last form edit before saving.');
+				}
+			}
 			// this.addToggleSetting('enableEditEncryptedPDF')
 			// .setName('Enable editing encrypted PDF files');
 		}

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1282,6 +1282,10 @@ declare module 'obsidian' {
         getConfig(name: 'newFileLocation'): 'root' | 'current' | 'folder';
         getConfig(name: 'attachmentFolderPath'): string;
         getAvailablePath(pathWithoutExtension: string, extension: string): string;
+        /** Obsidian’s runtime accepts Uint8Array in many cases; widen typing for pdf-lib/pdf.js outputs. */
+        modifyBinary(file: TFile, data: ArrayBuffer | Uint8Array): Promise<void>;
+        /** Obsidian’s runtime accepts Uint8Array in many cases; widen typing for pdf-lib/pdf.js outputs. */
+        createBinary(path: string, data: ArrayBuffer | Uint8Array): Promise<TFile>;
     }
 
     interface MetadataCache {

--- a/styles.css
+++ b/styles.css
@@ -268,6 +268,40 @@ settings:
     cursor: not-allowed;
 }
 
+.pdf-plus-form-save-confirm-text {
+    margin-bottom: var(--size-4-2);
+}
+
+.pdf-plus-form-save-confirm-actions {
+    display: flex;
+    gap: var(--size-2-2);
+    justify-content: flex-end;
+}
+
+.pdf-plus-form-save-wait-row {
+    display: flex;
+    align-items: center;
+    gap: var(--size-2-3);
+    margin-bottom: var(--size-4-2);
+}
+
+.pdf-plus-form-save-wait-spinner.is-spinning > svg {
+    animation: pdf-plus-spin 1s linear infinite;
+}
+
+.pdf-plus-form-save-wait-message {
+    color: var(--text-muted);
+}
+
+@keyframes pdf-plus-spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
 .menu .menu-item.pdf-plus-color-menu-item {
     padding-left: 0;
 

--- a/styles.css
+++ b/styles.css
@@ -241,6 +241,33 @@ settings:
     }
 }
 
+.pdf-plus-form-save-indicator {
+    display: none;
+    font-size: var(--font-ui-smaller);
+    font-variant-numeric: tabular-nums;
+    padding: 0 var(--size-2-2);
+    line-height: 1;
+    white-space: nowrap;
+    user-select: none;
+    -webkit-user-select: none;
+    align-self: center;
+
+    &.is-dirty {
+        color: var(--text-warning);
+    }
+
+    &.is-saving {
+        color: var(--text-accent);
+    }
+}
+
+.annotationLayer input[data-pdf-plus-was-disabled],
+.annotationLayer textarea[data-pdf-plus-was-disabled],
+.annotationLayer select[data-pdf-plus-was-disabled] {
+    opacity: 0.55;
+    cursor: not-allowed;
+}
+
 .menu .menu-item.pdf-plus-color-menu-item {
     padding-left: 0;
 
@@ -578,6 +605,62 @@ body {
     z-index: 1000;
     border: dashed var(--background-modifier-border) 2px;
     background-color: hsla(var(--interactive-accent-hsl), 0.15);
+}
+
+/* PDF form fields (annotation layer widgets)
+ * Obsidian themes often apply generous padding/line-height to inputs, which can make PDF form widgets
+ * behave as if they have very little usable space (e.g. only one digit visible at a time).
+ * Keep these controls compact so the usable text area matches the visual box. */
+.pdf-container .annotationLayer input,
+.pdf-container .annotationLayer textarea,
+.pdf-container .annotationLayer select {
+    box-sizing: border-box;
+    min-height: 0;
+}
+
+.pdf-container .annotationLayer input:not([type="checkbox"]):not([type="radio"]):not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="file"]):not([type="image"]):not([type="range"]):not([type="color"]),
+.pdf-container .annotationLayer textarea {
+    padding: 0 1px !important;
+    line-height: 1 !important;
+    margin: 0 !important;
+}
+
+/* Keep PDF.js choice/check widgets stable against theme input styles.
+ * Some themes apply select/checkbox styling that hides selected dropdown text
+ * or shrinks checkbox marks, even though values are correct internally. */
+.pdf-container .annotationLayer select {
+    margin: 0 !important;
+    padding: 0 1px !important;
+    line-height: 1.1 !important;
+    background: transparent !important;
+    color: inherit !important;
+    -webkit-text-fill-color: currentColor !important;
+    appearance: auto !important;
+    -webkit-appearance: menulist !important;
+    text-indent: 0 !important;
+}
+
+.pdf-container .annotationLayer input[type="checkbox"],
+.pdf-container .annotationLayer input[type="radio"] {
+    margin: 0 !important;
+    padding: 0 !important;
+    min-width: 0 !important;
+    min-height: 0 !important;
+    box-sizing: border-box !important;
+    box-shadow: none !important;
+    transform: none !important;
+    appearance: auto !important;
+    -webkit-appearance: auto !important;
+    accent-color: currentColor !important;
+}
+
+/* Keep words intact in multiline PDF form fields.
+ * This prevents single words from being split across lines; font auto-fit handles sizing. */
+.pdf-container .annotationLayer textarea {
+    word-break: normal !important;
+    overflow-wrap: normal !important;
+    word-wrap: normal !important;
+    hyphens: none !important;
 }
 
 /* From Obsidian's app.css (.annotationLayer .mod-focused /  .annotationLayer .boundingRect)*/


### PR DESCRIPTION
I needed a way to edit and save form-fillable PDFs inside of Obsidian for a DnD planning system, so I extended this plugin to support this functionality, as well as a couple QoL improvements I wanted. I figured I should share this if it'd be useful to anyone else. This was almost exclusively vibe coded, so while I tried my best to make sure the code was clean- if there is anything that should be cleaned up, refactored, or rewritten elsewhere- I can make the necessary changes. I've only tested this on a couple different form fillable PDFs, primarily the [DnD 5e Character Sheet](https://media.wizards.com/2016/dnd/downloads/5E_CharacterSheet_Fillable.pdf). 

You can access the new functionality in the PDF++ settings, enabling PDF editing and 'Enable saving PDF form fields'. This PR addresses #522 

New functionality:
- There is a 'Save' button in PDF view now, clicking it will save the current form edits to the PDF
- Next to the save button is a label that will display 'Unsaved' if changes are present and haven't been saved to the file. 
- During file saving the forms are locked from editing (to prevent changes being reverted after save completes), and a progress percentage is displayed next to save button
- In the settings, automatic saving can be enabled- which will automatically save the PDF file on a configurable interval when there are unsaved changes and no form field focused
- Closing the active PDF tab, or switching the active file, while there are unsaved changes will open a modal to allow saving to complete before its closed- to prevent lost changes
- Improved text sizing formatting inside form fields

Known issues:
- Switching the active file to another while there are unsaved changes will open a modal and allow it to finish saving, but the active file switch will not occur afterwards (only a small annoyance)


If there are any PDF specific issues encountered, if you send them here I'm happy to address that as well.