### PR TITLE
Fix cropped embed width in live preview

### DIFF
--- a/src/pdf-cropped-embed.ts
+++ b/src/pdf-cropped-embed.ts
@@ -24,7 +24,7 @@ export class PDFCroppedEmbed extends Component implements Embed {
         this.containerEl = ctx.containerEl;
         this.rect = window.pdfjsLib.Util.normalizeRect(rect);
         this.containerEl.addClass('pdf-cropped-embed');
-        if (width) this.containerEl.setAttribute('width', '' + width);
+        this.applyWidth();
     }
 
     onload() {
@@ -61,13 +61,25 @@ export class PDFCroppedEmbed extends Component implements Embed {
                 imgEl.addEventListener('load', () => resolve());
                 imgEl.addEventListener('error', (err) => reject(err));
 
-                const width = this.containerEl.getAttribute('width');
                 const height = this.containerEl.getAttribute('height');
-                if (width) imgEl.setAttribute('width', width);
+                const width = this.getValidWidth();
+                if (width) imgEl.setAttribute('width', '' + width);
                 if (height) imgEl.setAttribute('height', height);
             });
             activeWindow.setTimeout(() => reject(), 5000);
         });
+    }
+
+    getValidWidth() {
+        return typeof this.width === 'number' && Number.isFinite(this.width) && this.width > 0 ? this.width : undefined;
+    }
+
+    applyWidth() {
+        const width = this.getValidWidth();
+        if (!width) return;
+
+        this.containerEl.setAttribute('width', '' + width);
+        this.containerEl.style.setProperty('--container-pdf-cropped-width', `${width}px`);
     }
 
     async computeDataUrl() {


### PR DESCRIPTION
Hi, I noticed that the `&width=` argument in embeds does not really work in live preview. I cooked up a small fix for it using Codex; please, see whether you think it is worth merging into upstream (I know that you are currently doing a major refactor).

----

Fixes cropped PDF embeds with an explicit `width` parameter in Live Preview.

Previously the width was preserved as a `width` attribute, but Live Preview styling sizes the cropped embed container from `--container-pdf-cropped-width`. This meant the generated image could have the intended width while the container still used the default line width.

This change validates the parsed width once, applies it to the container attribute, sets `--container-pdf-cropped-width`, and reuses the same validated width for the rendered image.

Tested:
- `npm run build`
- `npm run lint`