### PR TITLE
Rectangular selection precision option

### DIFF
--- a/src/lib/copy-link.ts
+++ b/src/lib/copy-link.ts
@@ -425,7 +425,8 @@ export class copyLinkLib extends PDFPlusLibSubmodule {
 
         if (!checking) {
             const display = this.getDisplayText(child, undefined, file, pageNumber, '');
-            let subpath = `#page=${pageNumber}&rect=${rect.map((num) => Math.round(num)).join(',')}`;
+            const precision = this.settings.rectSelectionPrecisionDecimals;
+            let subpath = `#page=${pageNumber}&rect=${rect.map((num) => Math.round(num * 10**precision)/10**precision).join(',')}`;
             if (colorName) subpath += `&color=${colorName}`;
             const embedLink = this.lib.generateMarkdownLink(file, sourcePath ?? '', subpath, display);
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -253,6 +253,7 @@ export interface PDFPlusSettings {
 	rectImageFormat: 'file' | 'data-url';
 	rectImageExtension: ImageExtension;
 	rectEmbedResolution: number;
+	rectSelectionPrecisionDecimals: number;
 	zoomToFitRect: boolean;
 	rectFollowAdaptToTheme: boolean;
 	includeColorWhenCopyingRectLink: boolean;
@@ -542,6 +543,7 @@ export const DEFAULT_SETTINGS: PDFPlusSettings = {
 	zoomToFitRect: false,
 	rectFollowAdaptToTheme: true,
 	rectEmbedResolution: 100,
+	rectSelectionPrecisionDecimals: 0,
 	includeColorWhenCopyingRectLink: true,
 	backlinkIconSize: 50,
 	showBacklinkIconForSelection: false,
@@ -1830,6 +1832,9 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 				el.appendChild(this.createLinkTo('dblclickEmbedToOpenLink'));
 				el.appendText(' option as well.');
 			}));
+		this.addSliderSetting('rectSelectionPrecisionDecimals', 0, 15, 1)
+			.setName('Selection precision (coordinate decimal places)')
+			.setDesc('Set the precision of the rectangular selection tool by the number of decimal places used for the coordinate points. Default is 0.');
 
 
 		this.addHeading('PDF++ callouts', 'callout', 'lucide-quote')


### PR DESCRIPTION
Added the option of increasing the precision of the markdown output of the rectangular selection tool. This is useful when you are selecting very small areas in the PDF, such that the fine details of the selection are not lost during the annotation visualization.

You choose the precision by selecting the decimal places of the coordinate points. For example:
  0 => [[ex.pdf#page=1&rect=123,123,123,123]]
  2 => [[ex.pdf#page=1&rect=123.45,123.45,123.45,123.45]]
...and so on, up to a maximum of 15 decimal places.

