### PR TITLE
Don't let backlink highlights swallow mousedown (fixes text selection over highlighted text)

### DIFF
--- a/src/backlink-pointer-delegate.ts
+++ b/src/backlink-pointer-delegate.ts
@@ -1,0 +1,202 @@
+import { Component } from 'obsidian';
+
+import { isTargetHTMLElement } from 'utils';
+
+
+interface HitRect {
+    el: HTMLElement;
+    /** Coordinates relative to the top-left corner of the backlink highlight layer. */
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+}
+
+
+/**
+ * Backlink highlights are absolutely-positioned `<div>`s stacked on top of PDF.js's text layer.
+ * They used to have `pointer-events: auto` so that they could receive the `mouseover` (hover
+ * preview & backlink pane highlighting), `dblclick` (open backlink) and `contextmenu` events.
+ *
+ * The problem is that `pointer-events` is all-or-nothing. By taking part in hit-testing, the
+ * highlights also swallow `mousedown`, which is the event the browser uses to anchor a text
+ * selection. A highlight `<div>` contains no text node, so a mousedown on it yields no caret
+ * position and dragging over already-highlighted text selects nothing or jumps around.
+ * The problem is even worse than it looks because the highlights are painted with a padding
+ * and a negative margin of the same size, which makes their hit box slightly larger than the
+ * text they cover.
+ *
+ * None of the three events above have anything to do with text selection, so the highlights are
+ * now click-through (`pointer-events: none`, see `styles.css`) and this class re-creates those
+ * events instead: it listens on the page element, hit-tests the pointer position against the
+ * highlight rectangles, and re-dispatches the event on the highlight under the cursor.
+ * Text selection is left entirely to the text layer, exactly as if no highlight were there.
+ */
+export class BacklinkHighlightPointerDelegate extends Component {
+    private hoveredEl: HTMLElement | null = null;
+    private hitRects: HitRect[] | null = null;
+    private hitRectsLayerSize: { width: number, height: number } | null = null;
+    private pendingMouseMove: MouseEvent | null = null;
+    private frameId: number | null = null;
+
+    constructor(public pageEl: HTMLElement, public layerEl: HTMLElement) {
+        super();
+    }
+
+    onload() {
+        this.registerDomEvent(this.pageEl, 'mousemove', (evt) => this.queueHoverUpdate(evt));
+        this.registerDomEvent(this.pageEl, 'mouseleave', (evt) => this.setHovered(null, evt));
+        this.registerDomEvent(this.pageEl, 'dblclick', (evt) => this.redispatch(evt));
+        this.registerDomEvent(this.pageEl, 'contextmenu', (evt) => this.redispatch(evt));
+    }
+
+    onunload() {
+        if (this.frameId !== null) {
+            this.pageEl.win.cancelAnimationFrame(this.frameId);
+            this.frameId = null;
+        }
+        this.pendingMouseMove = null;
+        this.hoveredEl = null;
+        this.hitRects = null;
+        this.hitRectsLayerSize = null;
+    }
+
+    /** Force the hit rectangles to be recomputed, e.g. after highlights have been added or removed. */
+    invalidateHitRects() {
+        this.hitRects = null;
+        this.hitRectsLayerSize = null;
+    }
+
+    /**
+     * `mousemove` fires far more often than once per frame, and each hover update reads layout,
+     * so coalesce them into a single update per animation frame.
+     */
+    private queueHoverUpdate(evt: MouseEvent) {
+        // Don't begin a hover interaction while a button is held down: the user is dragging
+        // (most likely selecting text), and popping up a hover preview mid-drag steals the pointer.
+        if (evt.buttons !== 0) {
+            this.setHovered(null, evt);
+            return;
+        }
+
+        this.pendingMouseMove = evt;
+
+        if (this.frameId !== null) return;
+        this.frameId = this.pageEl.win.requestAnimationFrame(() => {
+            this.frameId = null;
+            const pending = this.pendingMouseMove;
+            this.pendingMouseMove = null;
+            if (pending) this.setHovered(this.hitTest(pending), pending);
+        });
+    }
+
+    private setHovered(el: HTMLElement | null, source: MouseEvent) {
+        if (el === this.hoveredEl) return;
+
+        const prevEl = this.hoveredEl;
+        this.hoveredEl = el;
+
+        // Dispatch the `mouseout` first so that the previous highlight's cleanup runs before
+        // the new one's `mouseover`, which is the order the native events would arrive in.
+        if (prevEl) this.dispatch(prevEl, 'mouseout', source, el);
+        if (el) this.dispatch(el, 'mouseover', source, prevEl);
+    }
+
+    private redispatch(evt: MouseEvent) {
+        const el = this.hitTest(evt);
+        if (!el) return;
+
+        const dispatched = this.dispatch(el, evt.type, evt);
+        // The handlers signal "I've handled this" by calling `preventDefault` (this is how
+        // `onBacklinkVisualizerContextMenu` stops the generic PDF context menu from also
+        // showing up), so the original event has to be marked as handled as well.
+        if (dispatched.defaultPrevented) evt.preventDefault();
+    }
+
+    private dispatch(el: HTMLElement, type: string, source: MouseEvent, relatedTarget: EventTarget | null = null) {
+        const win = source.win as Window & typeof globalThis;
+        // `bubbles: false` matters: this event is dispatched from a listener registered on an
+        // ancestor of `el`, so a bubbling event would re-enter this delegate forever.
+        // Every handler involved is registered directly on the highlight element anyway.
+        const evt = new win.MouseEvent(type, {
+            bubbles: false,
+            cancelable: true,
+            view: win,
+            detail: source.detail,
+            screenX: source.screenX,
+            screenY: source.screenY,
+            clientX: source.clientX,
+            clientY: source.clientY,
+            ctrlKey: source.ctrlKey,
+            altKey: source.altKey,
+            shiftKey: source.shiftKey,
+            metaKey: source.metaKey,
+            button: source.button,
+            buttons: source.buttons,
+            relatedTarget,
+        });
+        el.dispatchEvent(evt);
+
+        return evt;
+    }
+
+    private hitTest(evt: MouseEvent): HTMLElement | null {
+        // Elements in the annotation layer are still `pointer-events: auto` and handle their own
+        // events, so don't steal events that landed on one of them.
+        if (isTargetHTMLElement(evt, evt.target) && evt.target.closest('.annotationLayer section')) {
+            return null;
+        }
+
+        const layerRect = this.layerEl.getBoundingClientRect();
+        const x = evt.clientX - layerRect.left;
+        const y = evt.clientY - layerRect.top;
+
+        const hitRects = this.getHitRects(layerRect);
+        // Iterate in reverse document order so that the topmost highlight wins,
+        // which is what the native hit-testing would have done.
+        for (let i = hitRects.length - 1; i >= 0; i--) {
+            const { el, left, top, right, bottom } = hitRects[i];
+            if (left <= x && x <= right && top <= y && y <= bottom) return el;
+        }
+
+        return null;
+    }
+
+    /**
+     * The hit rectangles are stored relative to the highlight layer, so they survive scrolling
+     * and only have to be recomputed when the layer itself is resized, i.e. on zoom or rotation.
+     * (A re-render clears the highlights and this delegate along with them.)
+     */
+    private getHitRects(layerRect: DOMRect): HitRect[] {
+        const cachedSize = this.hitRectsLayerSize;
+        if (this.hitRects
+            && cachedSize
+            && Math.abs(cachedSize.width - layerRect.width) < 0.5
+            && Math.abs(cachedSize.height - layerRect.height) < 0.5) {
+            return this.hitRects;
+        }
+
+        const hitRects: HitRect[] = [];
+
+        for (const child of Array.from(this.layerEl.children)) {
+            if (!child.instanceOf(HTMLElement)) continue;
+            if (!child.hasClass('pdf-plus-backlink')) continue;
+            // Bounding rectangles of backlinked annotations have always been non-interactive.
+            if (child.hasClass('pdf-plus-annotation-bounding-rect')) continue;
+
+            const rect = child.getBoundingClientRect();
+            hitRects.push({
+                el: child,
+                left: rect.left - layerRect.left,
+                top: rect.top - layerRect.top,
+                right: rect.right - layerRect.left,
+                bottom: rect.bottom - layerRect.top,
+            });
+        }
+
+        this.hitRects = hitRects;
+        this.hitRectsLayerSize = { width: layerRect.width, height: layerRect.height };
+
+        return hitRects;
+    }
+}

--- a/src/backlink-visualizer.ts
+++ b/src/backlink-visualizer.ts
@@ -8,6 +8,7 @@ import { MultiValuedMap, getTextLayerInfo, isCanvas, isEmbed, isHoverPopover, is
 import { onBacklinkVisualizerContextMenu } from 'context-menu';
 import { BidirectionalMultiValuedMap } from 'utils';
 import { MergedRect } from 'lib/highlights/geometry';
+import { BacklinkHighlightPointerDelegate } from 'backlink-pointer-delegate';
 
 
 export class PDFBacklinkVisualizer extends PDFPlusComponent {
@@ -38,6 +39,7 @@ export class BacklinkDomManager extends PDFPlusComponent {
     private pagewiseCacheToDomsMap = new Map<number, BidirectionalMultiValuedMap<PDFBacklinkCache, HTMLElement>>;
     private pagewiseStatus = new Map<number, { onPageReady: boolean, onTextLayerReady: boolean, onAnnotationLayerReady: boolean }>;
     private pagewiseOnClearDomCallbacksMap = new MultiValuedMap<number, () => any>();
+    private pagewisePointerDelegate = new Map<number, BacklinkHighlightPointerDelegate>();
 
     constructor(visualizer: PDFViewerBacklinkVisualizer) {
         super(visualizer.plugin);
@@ -59,6 +61,12 @@ export class BacklinkDomManager extends PDFPlusComponent {
     }
 
     clearDomInPage(pageNumber: number) {
+        const delegate = this.pagewisePointerDelegate.get(pageNumber);
+        if (delegate) {
+            this.removeChild(delegate);
+            this.pagewisePointerDelegate.delete(pageNumber);
+        }
+
         const cacheToDoms = this.getCacheToDomsMap(pageNumber);
         for (const el of cacheToDoms.values()) {
             // Avoid removing elements in the annotation layer
@@ -113,6 +121,30 @@ export class BacklinkDomManager extends PDFPlusComponent {
                 this.setHighlightColor(el, color);
             }
         }
+
+        this.setUpPointerDelegate(pageNumber);
+    }
+
+    /**
+     * The highlights in the backlink highlight layer are click-through so that they don't
+     * break text selection (see `styles.css`), which means the mouse events hooked above
+     * never reach them on their own. This delegate re-dispatches those events based on the
+     * pointer position. See `BacklinkHighlightPointerDelegate` for the details.
+     */
+    setUpPointerDelegate(pageNumber: number) {
+        const existing = this.pagewisePointerDelegate.get(pageNumber);
+        if (existing) {
+            // The set of highlights may have changed since the delegate was created.
+            existing.invalidateHitRects();
+            return;
+        }
+
+        const pageView = this.visualizer.child.getPage(pageNumber);
+        const layerEl = pageView.div.querySelector<HTMLElement>('div.pdf-plus-backlink-highlight-layer');
+        if (!layerEl) return;
+
+        const delegate = this.addChild(new BacklinkHighlightPointerDelegate(pageView.div, layerEl));
+        this.pagewisePointerDelegate.set(pageNumber, delegate);
     }
 
     hookBacklinkOpeners(el: HTMLElement, cache: PDFBacklinkCache) {

--- a/styles.css
+++ b/styles.css
@@ -365,7 +365,12 @@ settings:
 
 .pdf-plus-backlink-highlight-layer .pdf-plus-backlink {
     position: absolute;
-    pointer-events: auto;
+    /* The highlights must not take part in hit-testing. They sit on top of the text layer and
+       contain no text node, so a mousedown landing on one gives the browser no caret position
+       to anchor a text selection to, which makes already-highlighted text impossible to select.
+       The mouse events they do need (mouseover/mouseout, dblclick, contextmenu) are re-dispatched
+       by BacklinkHighlightPointerDelegate instead. */
+    pointer-events: none;
 }
 
 .pdf-plus-backlink-highlight-layer .pdf-plus-backlink.pdf-plus-backlink-selection {


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.

---

### Description

**Fixes #456.** Text selection breaks over text that already carries a backlink highlight: the highlights are absolutely-positioned divs with `pointer-events: auto`, so a `mousedown` lands on an element with no text in it and the browser has no caret to anchor to.

`pointer-events` is all-or-nothing, so the highlights are made click-through and the four events they actually need (`mouseover`/`mouseout` for hover preview and backlink-pane highlighting, `dblclick`, `contextmenu`) are re-created by hit-testing the pointer against the highlight rectangles. +240/-1, one new file.

Happy to put it behind a setting defaulting to today's behaviour if you'd prefer a more conservative rollout.

<details>
<summary>Full report: what it is, why this approach, what was tried instead, and testing</summary>

## Problem

Text selection is unreliable over text that already has a backlink highlight on it. Dragging across a highlight often selects nothing, collapses the selection, or jumps by whole elements. Text immediately *next to* a highlight is affected too.

Backlink highlights are absolutely-positioned `<div>`s in `.pdf-plus-backlink-highlight-layer`, stacked on top of PDF.js's text layer, with `pointer-events: auto` so that they can receive:

- `mouseover` / `mouseout` — hover preview (`hover-link`), backlink pane highlighting, `is-hovered`
- `dblclick` — `doubleClickHighlightToOpenBacklink`
- `contextmenu` — `onBacklinkVisualizerContextMenu`

But `pointer-events` is all-or-nothing. By taking part in hit-testing, the highlights also swallow **`mousedown`**, which is the event the browser uses to anchor a text selection. A highlight `<div>` contains no text node, so a mousedown landing on one gives no caret position, and the drag-selection that follows has nothing sensible to extend from.

Two things make it more noticeable than it sounds:

- the highlights are painted with `padding: 0.05em` and a negative `margin` of the same size (`styles.css`), so the hit box is *larger* than the text it covers — text that visibly isn't highlighted is still blocked;
- with `hoverHighlightAction: "preview"`, a hover preview can pop up in the middle of a drag.

## Fix

None of the three events the highlights need have anything to do with text selection. So this PR makes them click-through (`pointer-events: none`) and re-creates those events from a listener on the page element instead — `BacklinkHighlightPointerDelegate` hit-tests the pointer position against the highlight rectangles and re-dispatches the event on the highlight under the cursor. Text selection is left entirely to the text layer, exactly as if no highlight were there.

Details worth flagging for review:

- **Hit-testing is geometric, not `elementFromPoint`.** `document.elementFromPoint()` skips `pointer-events: none` elements, so it can't be used here. The rectangles are cached relative to the highlight layer, so they survive scrolling and are only recomputed when the layer is resized (zoom / rotation) or when the highlights change. `mousemove` handling is coalesced into one update per animation frame.
- **Re-dispatched events are non-bubbling.** Every handler in `BacklinkDomManager` is registered directly on the highlight element, so `bubbles: false` is enough — and it prevents the synthetic event from bubbling back up to the delegate's own listener on the page element.
- **`contextmenu` precedence is preserved.** `onBacklinkVisualizerContextMenu` signals "handled" via `preventDefault()`, and the generic PDF context menu checks `defaultPrevented`. The delegate propagates `defaultPrevented` from the synthetic event back to the original, so the ordering is unchanged.
- **The annotation layer is left alone.** Events that land on `.annotationLayer section` are not intercepted, so backlinked annotations (`annot.container`, which also carries `.pdf-plus-backlink` but lives outside the highlight layer) keep their native behavior. `.pdf-plus-annotation-bounding-rect` was already `pointer-events: none` and stays excluded from hit-testing.
- **No CSS `:hover` rules were relying on this.** The hover styling goes through the `hovered-highlight` / `is-hovered` classes, which are added from JS and are unaffected.
- **One deliberate behavior change:** hover interactions are suppressed while a mouse button is held down, so a hover preview no longer appears in the middle of a text-selection drag. It's two lines in `queueHoverUpdate` and easy to drop if you'd rather keep the old behavior.

Touch should if anything be better off, since `dblclick` / `contextmenu` are now resolved by position rather than by which element the finger landed on.

## Alternatives considered

- **`pointer-events: none` with no delegation** — this is the workaround users can already apply with a CSS snippet, but it silently kills hover preview and double-click-to-open.
- **Disabling `pointer-events` on mousedown** (e.g. from a capture-phase listener) — doesn't work: the browser has already hit-tested and anchored the selection by the time the event is dispatched.
- **Re-dispatching a synthetic `mousedown` at the text layer** — doesn't work either: untrusted events don't initiate a native selection.
- **Implementing drag-selection manually** with `caretPositionFromPoint` + `Selection.extend` — possible, but it means reimplementing autoscroll, double-click-to-select-word and triple-click-to-select-line.
- **Putting the highlight layer below the text layer** — the text layer's gaps make hit-testing inconsistent, and hover/dblclick would break in the same way as the first option.

I'm happy to put this behind a setting instead (defaulting to the current behavior) if you'd prefer a more conservative rollout.

## Testing

Built and typechecked against `main` (`0.40.31`); `eslint` clean. Manually exercised in Obsidian 1.12.4 on macOS:

- text selection over and immediately next to backlink highlights, including drags that start on a highlight — this is what was broken;
- hover preview over a highlight appears and dismisses correctly on mouse-out;
- the corresponding item in the backlink pane still highlights on hover and clears on mouse-out;
- double-click on a highlight opens the source note;
- right-click on a highlight shows the backlink context menu, and right-click elsewhere still shows the generic PDF context menu;
- hit-testing stays correct after zooming, and after scrolling away from a page and back;
- rectangular (`FitR`) backlinks and backlink icons still respond to hover / double-click / right-click.

One thing that is *not* affected, in case it comes up while testing: in a two-column PDF whose content stream interleaves the columns, dragging a selection across columns picks up text from the other column. That is the text layer's DOM order and is identical before and after this change (I A/B'd it against an unpatched build on the same file).

</details>
