### PR TITLE
Fix settings tab breaking on Obsidian 1.13 (#569)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -899,8 +899,17 @@ export default class PDFPlus extends Plugin {
 	}
 
 	requireModKeyForLinkHover(id = 'pdf-plus') {
-		// @ts-ignore
-		return this.app.internalPlugins.plugins['page-preview'].instance.overrides[id]
+		// Obsidian 1.13 renamed the page-preview plugin's per-source override record
+		// from `overrides` to `options`. Reading the old name threw a TypeError, which,
+		// because `PDFPlusSettingTab.display` is async and Obsidian does not await it,
+		// silently aborted the rendering of the settings tab halfway through.
+		// https://github.com/RyotaUshio/obsidian-pdf-plus/issues/569
+		// The page-preview plugin can also be disabled altogether, in which case there is
+		// no instance to read from, so fall back to the source's default in that case too.
+		const instance = this.app.internalPlugins.plugins['page-preview'].instance;
+		const overrides = instance?.options ?? instance?.overrides;
+
+		return overrides?.[id]
 			?? this.app.workspace.hoverLinkSources[id]?.defaultMod
 			?? false;
 	}

--- a/src/patchers/page-preview.ts
+++ b/src/patchers/page-preview.ts
@@ -8,6 +8,8 @@ export const patchPagePreview = (plugin: PDFPlus): boolean => {
     const app = plugin.app;
     const lib = plugin.lib;
     const pagePreviewInstance = app.internalPlugins.plugins['page-preview'].instance;
+    // The Page preview core plugin can be turned off, in which case there is nothing to patch.
+    if (!pagePreviewInstance) return false;
 
     // Patch the instance instead of the prototype to avoid conflicts with Hover Editor
     // https://github.com/nothingislost/obsidian-hover-editor/issues/259

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1120,7 +1120,14 @@ declare module 'obsidian' {
                 'page-preview': {
                     instance: {
                         onLinkHover(hoverParent: HoverParent, targetEl: HTMLElement | null, linktext: string, sourcePath: string, state: any): void;
-                    }
+                        /**
+                         * Per-hover-link-source overrides of "require Mod key to trigger the preview".
+                         * Named `options` in Obsidian 1.13 and later, `overrides` before that.
+                         */
+                        options?: Record<string, boolean | undefined>;
+                        /** @deprecated Renamed to {@link options} in Obsidian 1.13. */
+                        overrides?: Record<string, boolean | undefined>;
+                    } | undefined
                     enabled: boolean;
                     enable(): void;
                     disable(): void;


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.

---

### Description

**Fixes #569, fixes #570.** On Obsidian 1.13 the settings tab renders two section icons and then stops. Obsidian 1.13 renamed the Page preview plugin's per-source override record from `overrides` to `options`, so `requireModKeyForLinkHover()` throws a `TypeError`; because `PDFPlusSettingTab.display()` is `async` and `renderTab()` neither awaits nor catches it, the failure surfaces only as an unhandled rejection and rendering stops silently.

Reads whichever name exists, falls back to the source's default, and also stops the load-time throw when the Page preview core plugin is disabled. +21/-3.

<details>
<summary>Full report: what it is, why this approach, what was tried instead, and testing</summary>

Fixes #569, fixes #570.

## The error

```
TypeError: Cannot read properties of undefined (reading 'pdf-plus')
    at PDFPlus.requireModKeyForLinkHover (main.ts:903)
    at PDFPlusSettingTab.addRequireModKeyOnHoverSetting (settings.ts:1409)
    at PDFPlusSettingTab.display (settings.ts:...)
    at e.renderTab (app.js)
    at t.openTab (app.js)
```

`requireModKeyForLinkHover()` reads the Page preview core plugin's per-source override record:

```ts
this.app.internalPlugins.plugins['page-preview'].instance.overrides[id]
```

Obsidian 1.13 renamed that record from `overrides` to `options`. In 1.13.7's `app.js` the plugin's constructor is now `this.options = {}`, it is populated in `onEnable` with `this.options = Object.assign({}, await loadData())`, and `onHoverLink` reads

```js
Object.hasOwn(this.options, id) ? this.options[id] : app.workspace.hoverLinkSources[id].defaultMod
```

So `instance.overrides` is `undefined`, and indexing it throws.

## Why it looks like "most of the settings are missing" rather than an error

`PDFPlusSettingTab.display()` is `async`, and 1.13's `SettingTab.renderTab()` calls it without awaiting or catching:

```js
prototype.renderTab = function () {
    this.settingItems.length > 0 ? renderDefinitions(this) : this.display()
}
```

The throw therefore becomes an unhandled promise rejection: rendering stops exactly where it happened, with no dialog and no effect on anything else. What is left on screen is whatever was added before that point — which is why every report shows precisely the first two icon headings ("Editing PDF files" and "Backlink highlighting") and nothing after them. `addRequireModKeyOnHoverSetting()` is first called from the "How backlinks are opened" section, right after those two.

For what it's worth, this is unrelated to 1.13's new declarative settings API. PDF++ does not implement `getSettingDefinitions()`, so `renderTab()` still takes the `display()` path; that path is intact. `openTab()` also re-appends `tab.containerEl` as before, so the tab's cached child elements (`headerContainerEl`, `contentEl`) are still valid.

## The fix

Read whichever record exists:

```ts
const instance = this.app.internalPlugins.plugins['page-preview'].instance;
const overrides = instance?.options ?? instance?.overrides;

return overrides?.[id]
    ?? this.app.workspace.hoverLinkSources[id]?.defaultMod
    ?? false;
```

The `??` chain is deliberately unchanged. `??` only falls through on null/undefined, so an explicit `false` override still takes precedence over the source's `defaultMod` — same semantics as the core plugin's `Object.hasOwn` check.

The typings now declare both names, with `overrides` marked deprecated, so the `@ts-ignore` could go away.

While here: `patchPagePreview()` calls `around(pagePreviewInstance, ...)` unconditionally, but Page preview is a core plugin that users can turn off, in which case `instance` is `undefined` and the plugin throws on load. Added a guard. This is pre-existing and unrelated to 1.13, but it is the same `instance` being unsafely dereferenced two lines away, and the typing change surfaces it.

## Testing

Verified on Obsidian 1.13.7 (installer 1.12.4), macOS, against `main` at 0.40.31: before the change the settings tab stops after "Backlink highlighting"; after it, the tab renders in full and the section icon bar is complete. `pnpm build` and `pnpm lint` are clean.

I could not test the pre-1.13 path on a real 1.12 install, but that branch is only reached when `instance.options` is absent, which is exactly the old behaviour.

</details>
