### PR TITLE
Don't record text selections wider than what was selected

### DIFF
--- a/src/patchers/pdf-internals.ts
+++ b/src/patchers/pdf-internals.ts
@@ -1,4 +1,4 @@
-import { Component, MarkdownRenderer, Notice, TFile, debounce, setIcon, setTooltip, Keymap, Menu, Platform, requireApiVersion, apiVersion } from 'obsidian';
+import { Component, MarkdownRenderer, Notice, TFile, debounce, setIcon, setTooltip, Keymap, Menu, Platform, requireApiVersion } from 'obsidian';
 import { around } from 'monkey-around';
 import { PDFDocumentProxy } from 'pdfjs-dist';
 
@@ -707,28 +707,42 @@ const patchPDFViewerChild = (plugin: PDFPlus, child: PDFViewerChild) => {
                 return embedLink.slice(1);
             };
         },
-        // The following patch fixes the bug reported in https://forum.obsidian.md/t/in-1-8-0-pdf-copy-link-to-selection-fails-to-copy-proper-links-in-some-cases/93545
+        // This patch was originally added for https://forum.obsidian.md/t/in-1-8-0-pdf-copy-link-to-selection-fails-to-copy-proper-links-in-some-cases/93545
         // (WhiteNoise said "will be fixed in 1.8.2" but it was actually fixed in Obsidian 1.8.1: see https://obsidian.md/changelog/2025-01-07-desktop-v1.8.1/)
-        // Therefore the method will be patched only if the Obsidian version is exactly 1.8.0.
-        // See also https://github.com/RyotaUshio/obsidian-pdf-plus/issues/327
-        ...(
-            apiVersion === '1.8.0'
-                ? {
-                    getTextSelectionRangeStr() {
-                        return function (this: PDFViewerChild, pageEl: HTMLElement) {
-                            const selection = pageEl.win.getSelection();
-                            const range = (selection && selection.rangeCount > 0) ? selection.getRangeAt(0) : null;
-                            const textSelectionRange = range && lib.copyLink.getTextSelectionRange(pageEl, range);
-                            if (textSelectionRange) {
-                                const { beginIndex, beginOffset, endIndex, endOffset } = textSelectionRange;
-                                return `${beginIndex},${beginOffset},${endIndex},${endOffset}`;
-                            }
-                            return null;
-                        };
-                    }
+        // and was therefore applied only on Obsidian 1.8.0. See also https://github.com/RyotaUshio/obsidian-pdf-plus/issues/327
+        //
+        // It is now applied unconditionally, because Obsidian's own implementation records
+        // selections that are wider than what the user selected. Its offset helper walks the
+        // text layer node's text nodes until it finds the range boundary's container:
+        //
+        //     function E1(e, t, n) {
+        //         if (!e.contains(t)) return null;
+        //         for (var i, r = e.doc.createNodeIterator(e, NodeFilter.SHOW_TEXT), o = n; (i = r.nextNode()) && t !== i;)
+        //             o += i.textContent.length;
+        //         return o
+        //     }
+        //
+        // That assumes the boundary sits on a text node. It can just as well sit on an element,
+        // where the offset counts child nodes instead of characters — which is what the browser
+        // produces when a selection ends on the seam between two text layer nodes (superscripts
+        // make this easy to hit, since they are separate text items) or when text is selected by
+        // double-clicking. For those, the loop never finds its target, runs to completion, and
+        // returns the node's entire text length.
+        //
+        // `lib.copyLink.getTextSelectionRange` measures with a range instead, which is defined
+        // for both kinds of boundary point. `textDivFirstIdx` keeps the 1.8.0 index adjustment.
+        getTextSelectionRangeStr() {
+            return function (this: PDFViewerChild, pageEl: HTMLElement) {
+                const selection = pageEl.win.getSelection();
+                const range = (selection && selection.rangeCount > 0) ? selection.getRangeAt(0) : null;
+                const textSelectionRange = range && lib.copyLink.getTextSelectionRange(pageEl, range);
+                if (textSelectionRange) {
+                    const { beginIndex, beginOffset, endIndex, endOffset } = textSelectionRange;
+                    return `${beginIndex},${beginOffset},${endIndex},${endOffset}`;
                 }
-                : {}
-        ),
+                return null;
+            };
+        },
         getPageLinkAlias(old) {
             return function (this: PDFViewerChild, page: number): string {
                 if (this.file) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -129,20 +129,27 @@ export function getTextLayerNode(pageEl: HTMLElement, node: Node) {
     return null;
 }
 
-// Taken from app.js.
+// Originally taken from app.js.
 // Takes care of the cases where the textLayerNode has multiple text nodes (I haven't experienced it though).
 // => Maybe it takes search matches into account
 export function getOffsetInTextLayerNode(textLayerNode: HTMLElement, node: Node, offsetInNode: number) {
     if (!textLayerNode.contains(node)) return null;
 
-    const iterator = textLayerNode.doc.createNodeIterator(textLayerNode, NodeFilter.SHOW_TEXT);
-    let textNode;
-    let offset = offsetInNode;
-    while ((textNode = iterator.nextNode()) && node !== textNode) { // Iterate over text nodes that come before `node`.
-        offset += textNode.textContent!.length;
-    }
+    // A range boundary point is either (text node, offset in characters) or
+    // (element, offset in *child nodes*), and both kinds show up here: when a selection ends
+    // exactly on the boundary between two text layer nodes, the browser normalizes the end
+    // point to (next textLayerNode, 0) rather than to the end of the previous text node.
+    //
+    // Measuring with a range handles both. Walking the text nodes and looking for `node`
+    // among them does not: for an element boundary point the comparison never matches, the
+    // loop runs to completion, and the function returns the length of the node's entire text.
+    // A selection ending right before ") for PCG expression..." was therefore recorded as
+    // ending *after* it, and the resulting highlight covered text that was never selected.
+    const range = textLayerNode.doc.createRange();
+    range.setStart(textLayerNode, 0);
+    range.setEnd(node, offsetInNode);
 
-    return offset;
+    return range.toString().length;
 }
 
 /**


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.

---

### Description

A link to a text selection can record a range wider than what was selected, so the highlight covers text that was never selected. Selecting exactly `cis-h²` recorded `selection=227,15,231,40` — 15 and 40 being the full lengths of items 227 and 231, neither of which was selected.

Two changes, both needed: the offset helper assumed a range boundary sits on a text node when it can equally sit on an *element* (superscripts and double-click selections produce exactly that), and the corrected helper was not the one being called, because the `getTextSelectionRangeStr` override was gated on the Obsidian version being exactly `1.8.0`. +51/-30.

CONTRIBUTING asks for an issue first — I didn't open one, since this turned up while testing #571 and the report is all here. Happy to open one if you would rather track it separately.

<details>
<summary>Full report: what it is, why this approach, what was tried instead, and testing</summary>

## Problem

A link to a text selection can record a range wider than what was selected, so the highlight covers text the user never selected.

Concrete case, in a paper where `cis-h²` is typeset with the superscript as its own text item. Selecting exactly `cis-h²` produced:

```markdown
> [!PDF|important] [[guan2025.pdf#page=2&selection=227,15,231,40&color=important|guan2025, p.1299]]
> > cis-h2 
```

The text items on that page:

```
227  "-heritability ("                            <- 15 characters
228  "cis-h"
229  "2"                                          <- superscript, its own item
230  " "
231  ") for PCG expression, lncRNA expression,"   <- 40 characters
```

`{{text}}` is `cis-h2 ` — items 228–230, exactly what was selected. But the recorded range runs from offset **15** in item 227 to offset **40** in item 231, and 15 and 40 are the full text lengths of those two items. Both boundaries were recorded as "the end of the node" regardless of where they actually were.

## Cause

Offsets are computed by walking the text layer node's text nodes until the range boundary's container is found:

```js
for (var i, r = e.doc.createNodeIterator(e, NodeFilter.SHOW_TEXT), o = n; (i = r.nextNode()) && t !== i;)
    o += i.textContent.length;
return o
```

That assumes the boundary sits on a text node. A range boundary point is either

- `(text node, offset in characters)`, or
- `(element, offset in **child nodes**)`,

and the second kind arrives here routinely. Instrumenting the viewer for the selection above shows the end boundary as an element boundary point:

```
text  : "cis-h2 "
start : #text "cis-h" len=5 @ 0
end   : <span class="textLayerNode" data-idx=231> children=1 @ 0
```

`(span231, 0)` means "before child 0", i.e. right before `") for PCG expression…"`. Superscripts make this easy to hit because they are separate text items, so a selection ending just after one lands on the seam between two nodes. Double-clicking to select a word produces element boundary points too.

For those, `t !== i` never becomes false, the iterator is exhausted, every text node's length is added, and the function returns the node's entire text length — whatever offset was asked for.

## Two commits, both needed

**1. Fix `getOffsetInTextLayerNode()`** to measure with a range, which is defined for both kinds of boundary point:

```ts
const range = textLayerNode.doc.createRange();
range.setStart(textLayerNode, 0);
range.setEnd(node, offsetInNode);

return range.toString().length;
```

**2. Apply the `getTextSelectionRangeStr` override unconditionally.** On its own, commit 1 changes nothing, because `getOffsetInTextLayerNode` is not what produces the link. `getTemplateVariables()` builds the subpath from `child.getTextSelectionRangeStr()`, and that method is only overridden when `apiVersion === '1.8.0'` — the narrow workaround for the unrelated 1.8.0 bug that Obsidian fixed in 1.8.1 (#327). On every other version it is Obsidian's own method, using the helper PDF++'s copy was taken from, with the identical flaw. `E1` in Obsidian 1.13.7's `app.js`:

```js
function E1(e, t, n) {
    if (!e.contains(t)) return null;
    for (var i, r = e.doc.createNodeIterator(e, NodeFilter.SHOW_TEXT), o = n; (i = r.nextNode()) && t !== i;)
        o += i.textContent.length;
    return o
}
```

`textDivFirstIdx` still applies the 1.8.0 index adjustment, so behaviour on 1.8.0 is unchanged.

Since the underlying bug is in Obsidian core, it is probably worth reporting there as well — this PR is a workaround, though `getOffsetInTextLayerNode` needed fixing on its own merits anyway, as it is also used by `getPageAndTextRangeFromSelection`.

## Testing

Unit-level, comparing the old and new offset implementations against the DOM structure above (jsdom):

| boundary point | expected | old | new |
| --- | --- | --- | --- |
| `(div231, 0)` — right before `") for PCG…"` | 0 | **40** | 0 |
| `(div231, 1)` — right after `") for PCG…"` | 40 | **41** | 40 |
| `(div228, 0)` | 0 | **5** | 0 |
| `(div228, 1)` | 5 | **6** | 5 |
| `(div231.firstChild, 0)` | 0 | 0 | 0 |
| `(div231.firstChild, 5)` | 5 | 5 | 5 |
| `(div228.firstChild, 3)` | 3 | 3 | 3 |

Text-node boundary points are unchanged, so selections that were already recorded correctly are unaffected.

End to end, on Obsidian 1.13.7 / installer 1.12.4, macOS: with both commits, selecting `cis-h²` records only what was selected and the highlight matches it. With only the first commit, the original wrong range is still produced — which is how the second commit was found.

`pnpm build` and `pnpm lint` are clean.

## Possibly also fixes #537

I can't confirm this one — I don't have the reporter's PDF — but the numbers fit. That report is about double-click selections producing an invalid reference, with `selection=78,77,78,78`. If item 78's text is 77 characters long, `beginOffset = 77` is exactly the "returned the node's whole text length" symptom for an element boundary point, and `endOffset = 78` is the same for `(div78, 1)`. Double-clicking is one of the ways element boundary points arise, so it would be worth having the reporter retest.

The `{{text}}` truncation in #498 looks like a different symptom; I don't think this touches it.

</details>
