### PR TITLE
Lay the text layer out with the PDF's own fonts where they fit

### DIFF
--- a/src/lib/commands.ts
+++ b/src/lib/commands.ts
@@ -11,6 +11,8 @@ import { SidebarView } from 'pdfjs-enums';
 import { showContextMenuAtSelection } from 'context-menu';
 import { RestoreDefaultModal } from 'modals/restore-default-modal';
 import { DataviewInlineFieldsModal } from './dataview';
+import { alignTextLayer } from 'text-layer-fonts';
+import { reportTextLayerAlignment } from 'text-layer-fonts-debug';
 
 
 export class PDFPlusCommands extends PDFPlusLibSubmodule {
@@ -35,6 +37,10 @@ export class PDFPlusCommands extends PDFPlusLibSubmodule {
             //     checkCallback: (checking) => this.createCanvasCard(checking)
             // },
             {
+                id: 'report-text-layer-alignment',
+                name: 'Report text layer alignment for this page (debug)',
+                checkCallback: (checking) => this.reportTextLayerAlignment(checking)
+            }, {
                 id: 'context-menu',
                 name: 'Show context menu at selection',
                 checkCallback: (checking) => this.showContextMenu(checking)
@@ -500,6 +506,59 @@ export class PDFPlusCommands extends PDFPlusLibSubmodule {
         }
 
         return false;
+    }
+
+    /**
+     * Measure, in PDF points, how far the selectable text layer sits from the glyphs that are
+     * actually painted. Run it with "Align the text layer with the printed text" off and then on
+     * to see what that option buys.
+     */
+    reportTextLayerAlignment(checking: boolean) {
+        const viewer = this.lib.getPDFViewer(true);
+        if (!viewer) return false;
+
+        if (!checking) {
+            const pageView = this.lib.getPage(true);
+            if (!pageView?.textLayer) {
+                new Notice(`${this.plugin.manifest.name}: this page has no text layer yet.`);
+                return true;
+            }
+
+            const pageNumber = viewer.currentPageNumber;
+            const restore = this.plugin.settings.useEmbeddedFontsInTextLayer;
+
+            // Measure both states in one go rather than asking the user to flip the setting
+            // between two runs: it removes any doubt about which state a number came from.
+            alignTextLayer(pageView, false);
+            const off = reportTextLayerAlignment(pageView, pageNumber, 'OFF');
+
+            // Time a cold alignment of the whole page: this is what the option adds to the
+            // rendering of each page, and it is the only work it does per page.
+            const startedAt = performance.now();
+            alignTextLayer(pageView, true);
+            const elapsed = performance.now() - startedAt;
+
+            const on = reportTextLayerAlignment(pageView, pageNumber, 'ON');
+            alignTextLayer(pageView, restore);
+
+            console.log(`[PDF++] text layer alignment, page ${pageNumber}`, { off, on, alignMs: elapsed });
+            const summarize = (r: typeof off) =>
+                `${r.alignedNodes}/${r.items} nodes, ${r.elements} els, ${r.gaps.toFixed(0)}pt gaps `
+                + `| within-item drift: mean `
+                + `${r.meanAbsRelDx.toFixed(2)}pt, max ${r.maxAbsRelDx.toFixed(2)}pt `
+                + `| raw: mean ${r.meanAbsDx.toFixed(2)}pt, max ${r.maxAbsDx.toFixed(2)}pt, `
+                + `signed ${r.meanDx.toFixed(2)}pt `
+                + `| ${r.misHits}/${r.characters} mis-hits, `
+                + `${r.caretMisses}/${r.caretProbes} caret misses `
+                + `| skipped ${r.skipped.notAlignable}/${r.skipped.charsMismatch}/${r.skipped.domMismatch}`;
+            new Notice(
+                `${this.plugin.manifest.name} page ${pageNumber} (aligning took ${elapsed.toFixed(1)}ms)`
+                + `\nOFF: ${summarize(off)}\nON: ${summarize(on)}`,
+                15000
+            );
+        }
+
+        return true;
     }
 
     toggleAdaptToTheme(checking: boolean, enable?: boolean) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { InstallerVersionModal } from 'modals';
 import { PDFExternalLinkPostProcessor, PDFInternalLinkPostProcessor, PDFOutlineItemPostProcessor, PDFThumbnailItemPostProcessor } from 'post-process';
 import { BibliographyManager } from 'bib';
 import { DataviewInlineFieldsModal, withFilesWithInlineFields } from 'lib/dataview';
+import { alignTextLayer } from 'text-layer-fonts';
 
 
 export default class PDFPlus extends Plugin {
@@ -903,6 +904,14 @@ export default class PDFPlus extends Plugin {
 		return this.app.internalPlugins.plugins['page-preview'].instance.overrides[id]
 			?? this.app.workspace.hoverLinkSources[id]?.defaultMod
 			?? false;
+	}
+
+	/** Apply or undo the experimental text layer alignment in every open PDF viewer. */
+	refreshTextLayerAlignment() {
+		const align = this.settings.useEmbeddedFontsInTextLayer;
+		this.lib.workspace.iteratePDFViewerChild((child) => {
+			child.pdfViewer?.pdfViewer?._pages?.forEach((pageView) => alignTextLayer(pageView, align));
+		});
 	}
 
 	openSettingTab(): PDFPlusSettingTab {

--- a/src/patchers/pdf-internals.ts
+++ b/src/patchers/pdf-internals.ts
@@ -11,6 +11,7 @@ import { patchPDFOutlineViewer } from 'patchers';
 import { PDFViewerBacklinkVisualizer } from 'backlink-visualizer';
 import { PDFPlusToolbar } from 'toolbar';
 import { BibliographyManager } from 'bib';
+import { alignTextLayer } from 'text-layer-fonts';
 import { camelCaseToKebabCase, getCharactersWithBoundingBoxesInPDFCoords, getTextLayerInfo, hookInternalLinkMouseEventHandlers, isEmbed, isModifierName, isNonEmbedLike, selectDoubleClickedWord, selectTrippleClickedTextLayerNode, showChildElOnParentElHover } from 'utils';
 import { AnnotationElement, PDFOutlineViewer, PDFViewerComponent, PDFViewerChild, PDFSearchSettings, Rect, PDFAnnotationHighlight, PDFTextHighlight, PDFRectHighlight, ObsidianViewer, PDFPageView } from 'typings';
 import { SidebarView, SpreadMode } from 'pdfjs-enums';
@@ -289,6 +290,14 @@ const patchPDFViewerChild = (plugin: PDFPlus, child: PDFViewerChild) => {
                             }
                         });
                     }
+                }
+
+                if (this.pdfViewer?.eventBus) {
+                    // Experimental: re-position the text layer using the per-character boxes that
+                    // Obsidian's PDF.js exposes, so that hit-testing matches the painted glyphs.
+                    this.pdfViewer.eventBus.on('textlayerrendered', ({ source: pageView }) => {
+                        if (plugin.settings.useEmbeddedFontsInTextLayer) alignTextLayer(pageView, true);
+                    });
                 }
 
                 // Fix for the Obsidian core issue where the "find next" button in the find bar has a wrong icon

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -308,6 +308,7 @@ export interface PDFPlusSettings {
 	PATH: string;
 	autoCheckForUpdates: boolean;
 	fixObsidianTextSelectionBug: boolean;
+	useEmbeddedFontsInTextLayer: boolean;
 }
 
 export const DEFAULT_SETTINGS: PDFPlusSettings = {
@@ -595,6 +596,7 @@ export const DEFAULT_SETTINGS: PDFPlusSettings = {
 	PATH: '',
 	autoCheckForUpdates: true,
 	fixObsidianTextSelectionBug: true,
+	useEmbeddedFontsInTextLayer: false,
 };
 
 
@@ -3330,6 +3332,16 @@ export class PDFPlusSettingTab extends PluginSettingTab {
 				this.renderMarkdown([
 					`As of June 10, 2025, Obsidian 1.9 has a bug related to PDF text selection that prevents Obsidian from recognizing text selection ranges properly (see [here](https://github.com/RyotaUshio/obsidian-pdf-plus/discussions/450) for more details). `,
 					`This option adds a experimental workaround to mitigate the issue.`,
+				], setting.descEl);
+			});
+		this.addToggleSetting('useEmbeddedFontsInTextLayer', () => this.plugin.refreshTextLayerAlignment())
+			.setName(`Lay the text layer out with the PDF's own fonts (experimental)`)
+			.then((setting) => {
+				this.renderMarkdown([
+					`PDF.js lays out the invisible text layer that you actually select with a generic font rather than the PDF's own, and corrects only the total width of each line fragment. The selectable characters therefore drift away from the glyphs you see - by more than a character in a densely typeset paper, where dragging over \`74.1%\` can select \`4.1%)\`.`,
+					`The PDF's fonts are already loaded for the page to be drawn with. Where one of them also reproduces the character widths the PDF gives its text, this option names it on the text layer, so the text is laid out with the metrics it was set in. On a page of a Nature paper that takes the worst drift from 5.7pt to 1.7pt and the characters that select as a different character from 2093 to 32, out of 8131.`,
+					`Not every PDF can be helped. A font is built to be drawn with rather than to lay text out with, and where its characters do not answer to the text layer's own the font is left alone - so on some papers this changes little or nothing. It never applies a font that measures worse than the one PDF.js chose.`,
+					`It adds no elements to the page and costs a couple of milliseconds per page. What it cannot correct is the spacing a PDF puts between individual glyphs to justify a line, which stays approximated by the single stretch PDF.js applies.`,
 				], setting.descEl);
 			});
 		this.addToggleSetting('showStatusInToolbar')

--- a/src/text-layer-fonts-debug.ts
+++ b/src/text-layer-fonts-debug.ts
@@ -1,0 +1,257 @@
+import { PDFPageView, Rect, TextContentItem } from 'typings';
+import { getCharactersWithBoundingBoxesInPDFCoords, getOffsetInTextLayerNode, getTextLayerInfo, getTextLayerNode } from 'utils';
+import { ALIGNED, canAlign, charsMatchingStr, fontEffect, fontVerdicts, getBaseFontSize } from 'text-layer-fonts';
+
+/**
+ * Measuring what the option in `text-layer-fonts.ts` is worth, on whatever page is open. Nothing
+ * here is used by the feature itself; it exists so the claims made for it can be checked against a
+ * reader's own PDFs rather than taken on trust, and so that a change that quietly does nothing
+ * shows up as numbers that did not move.
+ */
+
+export interface AlignmentReport {
+    pageNumber: number;
+    /** Number of characters that could be compared. */
+    characters: number;
+    /** Text layer nodes this page currently has, and how many of them we have re-positioned. */
+    items: number;
+    alignedNodes: number;
+    /** Elements the text layer costs: one per node, plus the sub-spans we added. */
+    elements: number;
+    /**
+     * Total width, in PDF points, of the horizontal gaps between consecutive characters' hit boxes.
+     * PDF.js's one-span-per-item layout has none by construction; splitting an item into separately
+     * placed pieces can open them, and a gap is a spot where the cursor is over no text at all,
+     * which is what makes a drag stop tracking or jump.
+     */
+    gaps: number;
+    /** Why items were left out of the measurement. */
+    skipped: { notAlignable: number, charsMismatch: number, domMismatch: number };
+    /** Mean and max horizontal distance, in PDF points, between painted and hit-testable boxes. */
+    meanAbsDx: number;
+    maxAbsDx: number;
+    /**
+     * The same distance kept signed. A caret goes to whichever side of a character's box the
+     * pointer is nearer, so a layer sitting consistently left of the glyphs makes the character a
+     * drag starts on drop out of the selection unless the pointer is placed early - which is a
+     * different complaint from drifting, and needs the sign to tell apart from it.
+     */
+    meanDx: number;
+    /**
+     * The same distances measured relative to each item's own first character, which cancels any
+     * constant offset - both a real one in the item's placement and any bias in the client-to-PDF
+     * coordinate conversion this measurement goes through. This is the number that says how badly
+     * an item's characters are distributed *within* the item, which is what the drift actually is.
+     */
+    meanAbsRelDx: number;
+    maxAbsRelDx: number;
+    /**
+     * Characters whose painted midpoint lands inside a *different* character's hit box. These are
+     * the ones that produce a selection different from what the pointer was over.
+     */
+    misHits: number;
+    /**
+     * The same question asked the way the browser answers it while a selection is being dragged:
+     * aim at the middle of a painted character and ask `caretRangeFromPoint` which text position
+     * that is. Comparing boxes is the inverse of what dragging does, and on out-of-flow boxes the
+     * two are not guaranteed to agree, so this is the number that corresponds to what a pointer
+     * actually does. Only characters currently on screen can be asked.
+     */
+    caretProbes: number;
+    caretMisses: number;
+    worst: { text: string, dx: number } | null;
+}
+
+/**
+ * Compare where each character is painted (`item.chars`, straight from the PDF's content stream)
+ * against where the browser thinks it is (the DOM boxes it hit-tests against). Both are converted
+ * to PDF user space so the numbers are in points and independent of zoom.
+ */
+export function reportTextLayerAlignment(pageView: PDFPageView, pageNumber: number, label: string): AlignmentReport {
+    const report: AlignmentReport = {
+        pageNumber, characters: 0, items: 0, alignedNodes: 0, elements: 0, gaps: 0,
+        skipped: { notAlignable: 0, charsMismatch: 0, domMismatch: 0 },
+        meanAbsDx: 0, maxAbsDx: 0, meanDx: 0, meanAbsRelDx: 0, maxAbsRelDx: 0, misHits: 0,
+        caretProbes: 0, caretMisses: 0, worst: null,
+    };
+
+    const info = pageView.textLayer && getTextLayerInfo(pageView.textLayer);
+    if (!info) return report;
+
+    const { textDivs, textContentItems } = info;
+    let totalAbsDx = 0;
+    let totalDx = 0;
+    let totalAbsRelDx = 0;
+
+    // The client coordinate of the page's content origin, to turn a PDF point into somewhere a
+    // pointer could be. This is the inverse of what `toPDFCoords` does.
+    const pageEl = pageView.div;
+    const win = pageEl.win;
+    const doc = pageEl.doc;
+    const pageStyle = win.getComputedStyle(pageEl);
+    const pageRect = pageEl.getBoundingClientRect();
+    const pageLeft = pageRect.left + parseFloat(pageStyle.borderLeftWidth) + parseFloat(pageStyle.paddingLeft);
+    const pageTop = pageRect.top + parseFloat(pageStyle.borderTopWidth) + parseFloat(pageStyle.paddingTop);
+    const misses: { char: string, expected: number, got: number | null, text: string }[] = [];
+    let probeCounter = 0;
+
+    // What the document can actually lay text out with, and what this page asks for. If the two do
+    // not meet, naming the PDF's font on a node changes nothing and the numbers below come out
+    // exactly as they were.
+    const installed = new Set<string>();
+    doc.fonts.forEach((face) => installed.add(`${face.family}:${face.status}`));
+    const requested = new Map<string, string>();
+    for (let i = 0; i < textContentItems.length; i++) {
+        const item = textContentItems[i];
+        const div = textDivs[i];
+        if (!item?.fontName || !item.str || !div || requested.has(item.fontName)) continue;
+        // The family the node had before anything here touched it.
+        const fallback = div.dataset[ALIGNED] || div.style.fontFamily;
+        const size = getBaseFontSize(div);
+        if (!fallback || !(size > 0)) continue;
+        const { ratio } = fontEffect(doc, item.fontName, fallback, size, item.str);
+        const verdict = fontVerdicts.get(item.fontName);
+        requested.set(item.fontName, verdict
+            ? `${verdict.use ? 'USED' : 'rejected'} pdf=${verdict.family.toFixed(2)}pt `
+            + `fallback=${verdict.fallback.toFixed(2)}pt width×${ratio.toFixed(4)}`
+            : `undecided width×${ratio.toFixed(4)}`);
+    }
+    console.log(`[PDF++] ${label}: fonts`, {
+        installed: [...installed].slice(0, 30),
+        installedCount: installed.size,
+        // Per font: how far its character widths are from the PDF's own, against the same for the
+        // family PDF.js chose. The PDF's font is only used when it is both better and right.
+        perFont: Object.fromEntries(requested),
+    });
+
+    /** Ask the browser which text position the middle of a painted character is. */
+    const probeCaret = (div: HTMLElement, item: TextContentItem, box: Rect, index: number) => {
+        const [vx, vy] = pageView.viewport.convertToViewportPoint(
+            (box[0] + box[2]) / 2, (box[1] + box[3]) / 2
+        );
+        const x = pageLeft + vx;
+        const y = pageTop + vy;
+        // Off-screen points cannot be hit-tested, and asking anyway would count as a miss.
+        if (x < 0 || y < 0 || x > win.innerWidth || y > win.innerHeight) return;
+
+        report.caretProbes++;
+        const range = doc.caretRangeFromPoint(x, y);
+        const node = range?.startContainer;
+        const offset = node && getTextLayerNode(pageEl, node) === div
+            ? getOffsetInTextLayerNode(div, node, range!.startOffset)
+            : null;
+        // A caret sits between characters, so aiming at the middle of character `index` may
+        // legitimately come back as either of its two sides.
+        if (offset === index || offset === index + 1) return;
+
+        report.caretMisses++;
+        if (misses.length < 12) {
+            misses.push({
+                char: item.str.charAt(index), expected: index, got: offset,
+                text: item.str.slice(Math.max(0, index - 8), index + 8),
+            });
+        }
+    };
+    let worstDetail: {
+        index: number, at: number, str: string, base: number,
+        chars: NonNullable<TextContentItem['chars']>,
+        domBoxes: { char: string, rect: number[] }[],
+    } | null = null;
+
+    for (let i = 0; i < textDivs.length && i < textContentItems.length; i++) {
+        const div = textDivs[i];
+        const item = textContentItems[i];
+        if (!div || !item || !item.str) continue;
+
+        report.items++;
+        report.elements += 1 + div.childElementCount;
+        if (div.dataset[ALIGNED]) report.alignedNodes++;
+
+        if (!canAlign(item)) {
+            report.skipped.notAlignable++;
+            continue;
+        }
+        const chars = charsMatchingStr(item);
+        if (!chars) {
+            report.skipped.charsMismatch++;
+            continue;
+        }
+
+        const domBoxes = [...getCharactersWithBoundingBoxesInPDFCoords(pageView, div)];
+        if (domBoxes.length !== chars.length) {
+            report.skipped.domMismatch++;
+            continue;
+        }
+
+        const dxAtItemStart = domBoxes[0].rect[0] - chars[0].r[0];
+
+        for (let k = 1; k < domBoxes.length; k++) {
+            report.gaps += Math.max(0, domBoxes[k].rect[0] - domBoxes[k - 1].rect[2]);
+        }
+
+        for (let k = 0; k < chars.length; k++) {
+            const painted = chars[k].r;
+            const dom = domBoxes[k].rect;
+            const dx = dom[0] - painted[0];
+            const relDx = dx - dxAtItemStart;
+
+            report.characters++;
+            totalAbsDx += Math.abs(dx);
+            totalDx += dx;
+            totalAbsRelDx += Math.abs(relDx);
+            if (Math.abs(relDx) > report.maxAbsRelDx) report.maxAbsRelDx = Math.abs(relDx);
+            if (Math.abs(dx) > report.maxAbsDx) report.maxAbsDx = Math.abs(dx);
+            // Report the worst *relative* offset: a constant offset shared by a whole item is not
+            // what makes a drag land on the wrong character.
+            if (Math.abs(relDx) >= report.maxAbsRelDx) {
+                report.worst = { text: item.str.slice(Math.max(0, k - 12), k + 12), dx: relDx };
+                worstDetail = { index: i, at: k, str: item.str, chars, domBoxes, base: dxAtItemStart };
+            }
+
+            // Where does a click on the middle of the painted glyph actually land?
+            const midpoint = (painted[0] + painted[2]) / 2;
+            if (midpoint < Math.min(dom[0], dom[2]) || midpoint > Math.max(dom[0], dom[2])) {
+                report.misHits++;
+            }
+
+            // Sampled rather than exhaustive: each of these forces a hit test.
+            if (probeCounter++ % 4 === 0) probeCaret(div, item, painted, k);
+        }
+
+    }
+
+    if (misses.length) {
+        console.log(`[PDF++] ${label}: where the pointer actually lands, for the first misses:`);
+        console.table(misses);
+    }
+
+    // Show the character-by-character numbers for whichever line came off worst, so there is
+    // always something concrete to look at without having to know where to probe.
+    if (worstDetail) {
+        const { index, at, str, chars, domBoxes, base } = worstDetail;
+        const from = Math.max(0, at - 6);
+        const to = Math.min(chars.length, at + 7);
+        console.log(
+            `[PDF++] ${label}: worst line is item ${index} `
+            + `(offset of the whole item: ${base.toFixed(2)}pt): ${JSON.stringify(str)}`
+        );
+        console.table(
+            chars.slice(from, to).map((char, n) => {
+                const dx = domBoxes[from + n].rect[0] - char.r[0];
+                return {
+                    idx: from + n,
+                    char: char.c,
+                    paintedX: +char.r[0].toFixed(2),
+                    domX: +domBoxes[from + n].rect[0].toFixed(2),
+                    dx: +dx.toFixed(2),
+                    relDx: +(dx - base).toFixed(2),
+                };
+            })
+        );
+    }
+
+    report.meanAbsDx = report.characters ? totalAbsDx / report.characters : 0;
+    report.meanDx = report.characters ? totalDx / report.characters : 0;
+    report.meanAbsRelDx = report.characters ? totalAbsRelDx / report.characters : 0;
+    return report;
+}

--- a/src/text-layer-fonts.ts
+++ b/src/text-layer-fonts.ts
@@ -1,0 +1,266 @@
+import { PDFPageView, TextContentItem } from 'typings';
+import { getTextLayerInfo } from 'utils';
+
+/**
+ * PDF.js lays each text content item out as a single span containing the item's whole string, and
+ * corrects only the span's *total* width with `transform: scaleX(...)`.
+ *
+ * The font that span is rendered with is not the PDF's: in the worker, `getTextContent` reports
+ * `styles[fontName].fontFamily` as `font.fallbackName`, a generic family (`serif`, `sans-serif`).
+ * Since only the total width is corrected, character boxes agree with the painted glyphs at an
+ * item's two ends and drift in between - by as much as a character and a half in a line of a
+ * densely typeset paper. The text layer is what the browser hit-tests, so a drag over `74.1%` can
+ * select `4.1%)`.
+ *
+ * The embedded font is not missing, though: PDF.js installs it as an `@font-face` rule named after
+ * the font's loaded name, which is exactly what a text item reports as its `fontName`. Naming that
+ * family on the node makes the browser lay the text out with the metrics the page was set in, and
+ * leaves the text layer otherwise exactly as PDF.js built it - one span, one text node, one line
+ * box. That last part matters: earlier attempts here placed each word, and then each run, in its
+ * own span, which measured beautifully and dragged terribly, because turning a dragged pointer into
+ * a text position needs a line box to walk and `.textLayer span { position: absolute }` - a
+ * descendant selector, so it catches added spans too - leaves nothing to walk.
+ *
+ * What this cannot correct is the positioning the PDF does between glyphs, which is how justified
+ * text is spread; that stays with PDF.js's single stretch across the item.
+ */
+
+/** Data attributes holding what a node had before, so it can be put back. */
+export const ALIGNED = 'pdfPlusAligned';
+const ORIGINAL_TRANSFORM = 'pdfPlusTransform';
+
+/** The stretch PDF.js applies to an item, which has to be restated for the new font's metrics. */
+const SCALE_X_PATTERN = /scaleX\(([\d.]+)\)/;
+
+/**
+ * PDF.js writes the font size as `calc(var(--total-scale-factor) * 9.60px)` so that zooming is a
+ * pure CSS variable change, which means `parseFloat` gives NaN. Pull the px number out instead.
+ *
+ * Only the number matters, not what it is multiplied by: everything computed from it here is a
+ * ratio of two widths measured at that same size, so the scale factor cancels - which is also why
+ * the result stays correct across zoom levels.
+ */
+export function getBaseFontSize(div: HTMLElement): number {
+    const match = /(-?[\d.]+)px/.exec(div.style.fontSize);
+    return match ? parseFloat(match[1]) : NaN;
+}
+
+/**
+ * How far, in PDF points, a single character's width under a font may sit from the width the PDF
+ * gives it before that font is judged not to describe this text.
+ */
+const MAX_ADVANCE_ERROR = 0.5;
+
+/** Whether a font reproduces the PDF's own character widths, decided once per font. */
+export const fontVerdicts = new Map<string, { use: boolean, family: number, fallback: number }>();
+
+let measureCtx: CanvasRenderingContext2D | null = null;
+
+/** Single-character widths. A few hundred per font, unlike whole strings. */
+const charWidths = new Map<string, number>();
+
+function charWidth(doc: Document, font: string, char: string): number {
+    const key = font + char;
+    let width = charWidths.get(key);
+    if (width === undefined) {
+        width = measureText(doc, font, char);
+        if (charWidths.size > 4000) charWidths.clear();
+        charWidths.set(key, width);
+    }
+    return width;
+}
+
+/**
+ * The worst disagreement, in PDF points, between the character widths a font gives this text and
+ * the widths the PDF gives it.
+ *
+ * The two are in different units - one is CSS px at whatever size the node happens to be, the other
+ * PDF points - so they are compared after the single scale factor that best relates them, which is
+ * exactly the freedom PDF.js's own stretch has. What is left is the part no stretch can absorb:
+ * characters this font proportions differently from the PDF's, or does not have at all.
+ */
+function advanceError(doc: Document, font: string, str: string, chars: NonNullable<TextContentItem['chars']>): number {
+    let totalWidth = 0;
+    let totalAdvance = 0;
+    const widths: number[] = [];
+
+    for (let k = 0; k < chars.length; k++) {
+        const width = charWidth(doc, font, str.charAt(k));
+        widths.push(width);
+        totalWidth += width;
+        totalAdvance += chars[k].r[2] - chars[k].r[0];
+    }
+    if (!(totalWidth > 0) || !(totalAdvance > 0)) return Infinity;
+
+    const scale = totalAdvance / totalWidth;
+    let worst = 0;
+    for (let k = 0; k < widths.length; k++) {
+        worst = Math.max(worst, Math.abs(scale * widths[k] - (chars[k].r[2] - chars[k].r[0])));
+    }
+    return worst;
+}
+
+/**
+ * How much naming a family changes the width of the text it is being named for, as a ratio. Exactly
+ * 1 means the browser laid the text out with the fallback either way, so the family is not one it
+ * can use and naming it would achieve nothing.
+ *
+ * `document.fonts.check()` cannot answer this: a family nobody has heard of resolves to a fallback,
+ * which is loaded, so the answer is yes for every name. Nor can a fixed probe string - the fonts in
+ * a paper are usually subsets carrying only the glyphs that paper uses, and a probe of glyphs the
+ * subset happens not to have would be laid out entirely in the fallback. Measuring the item's own
+ * text is the only question worth asking, since that is the text that has to be laid out.
+ */
+export function fontEffect(doc: Document, family: string, fallback: string, fontSize: number, text: string) {
+    const before = measureText(doc, `${fontSize}px ${fallback}`, text);
+    const after = measureText(doc, `${fontSize}px "${family}", ${fallback}`, text);
+    return { before, after, ratio: before > 0 ? after / before : 1 };
+}
+
+function measureText(doc: Document, font: string, text: string): number {
+    if (!measureCtx) {
+        measureCtx = doc.createElement('canvas').getContext('2d');
+        if (!measureCtx) return 0;
+    }
+    if (measureCtx.font !== font) measureCtx.font = font;
+    return measureCtx.measureText(text).width;
+}
+
+/**
+ * `item.chars` covers the item's text *before* PDF.js trims it, so it can carry leading or
+ * trailing entries that `item.str` does not have. Line them up, and give up unless the result
+ * matches `item.str` character for character - a partial alignment would silently move text to
+ * the wrong place, which is worse than the drift we are fixing.
+ */
+export function charsMatchingStr(item: TextContentItem): TextContentItem['chars'] | null {
+    const { chars, str } = item;
+    if (!chars || chars.length < str.length || !str.length) return null;
+
+    const from = chars.findIndex((char) => char.c === str.charAt(0));
+    if (from === -1) return null;
+    const aligned = chars.slice(from, from + str.length);
+    if (aligned.length !== str.length) return null;
+
+    for (let i = 0; i < str.length; i++) {
+        if (aligned[i].c !== str.charAt(i)) return null;
+    }
+    return aligned;
+}
+
+export function canAlign(item: TextContentItem): boolean {
+    // Rotated or vertical text: PDF.js gives the span a `rotate(...)` of its own and our
+    // horizontal-only math does not apply.
+    if (item.transform[1] !== 0 || item.transform[2] !== 0) return false;
+    if (item.dir !== 'ltr') return false;
+    // PDF.js only corrects an item's width when it holds more than one character, so for a
+    // single-character item the span is *not* stretched to `item.width` and the frame this code
+    // works in would not be the frame the browser lays the span out in. There is nothing to fix
+    // inside a one-character item anyway.
+    if (item.str.length < 2) return false;
+    return item.width > 0;
+}
+
+/**
+ * Point a text layer node at the PDF's own font instead of the generic family PDF.js gives it.
+ *
+ * @returns whether the node was changed.
+ */
+export function alignTextLayerNode(div: HTMLElement, item: TextContentItem): boolean {
+    if (div.dataset[ALIGNED]) return false;
+    if (!item.str || !item.fontName) return false;
+
+    const doc = div.doc;
+    const family = item.fontName;
+    const previous = div.style.fontFamily;
+    if (!previous || previous === family) return false;
+
+    const fontSize = getBaseFontSize(div);
+    if (!(fontSize > 0)) return false;
+
+    // PDF.js's font files are built to be drawn with, not to be laid text out with: it draws a
+    // glyph by looking it up under a codepoint of its own choosing, so a font whose character map
+    // was synthesised from the PDF's encoding need not answer to the Unicode the text layer holds.
+    // Where it does not, characters come out of a fallback or with no width at all, and naming the
+    // font makes the layer worse rather than better - which is what happened to an Elsevier paper
+    // whose subset fonts left spaces and digits with zero advance.
+    //
+    // So ask, of this font and of the one PDF.js chose, which reproduces the widths the PDF itself
+    // gives these characters, and only take the PDF's font when it wins and is right.
+    let verdict = fontVerdicts.get(family);
+    if (!verdict) {
+        const chars = charsMatchingStr(item);
+        // Judge on an item with enough text to be worth judging on; a later one will do.
+        if (!chars || chars.length < 8) return false;
+
+        const fallbackError = advanceError(doc, `${fontSize}px ${previous}`, item.str, chars);
+        const familyError = advanceError(doc, `${fontSize}px "${family}", ${previous}`, item.str, chars);
+        verdict = {
+            use: familyError <= MAX_ADVANCE_ERROR && familyError < fallbackError,
+            family: familyError,
+            fallback: fallbackError,
+        };
+        fontVerdicts.set(family, verdict);
+    }
+    if (!verdict.use) return false;
+
+    // PDF.js sized this node by measuring its text in the generic family and stretching the result
+    // to the item's true width. Measured in the embedded font the text is a different width, so the
+    // stretch has to be restated in the same proportion, or the line would be scaled by the ratio
+    // between two fonts. PDF.js recomputes this itself the next time it lays the page out, reading
+    // the family from the node - which by then is this one.
+    //
+    // A width that does not move is also how a family the browser cannot use announces itself: the
+    // text was laid out in the fallback both times, and naming it would change nothing.
+    const { before, after, ratio } = fontEffect(doc, family, previous, fontSize, item.str);
+    if (!(before > 0) || !(after > 0)) return false;
+    if (Math.abs(ratio - 1) < 0.0005) return false;
+
+    const transform = div.style.transform;
+    div.dataset[ALIGNED] = previous;
+    div.dataset[ORIGINAL_TRANSFORM] = transform;
+    div.style.fontFamily = `"${family}"`;
+
+    // Items of a single character are given no stretch at all by PDF.js, and get none here either.
+    const scaled = transform.replace(SCALE_X_PATTERN, (_, value: string) =>
+        `scaleX(${(parseFloat(value) * before / after).toFixed(5)})`);
+    if (scaled !== transform) div.style.transform = scaled;
+
+    return true;
+}
+
+/** Put a text layer node back the way PDF.js built it. */
+export function revertTextLayerNode(div: HTMLElement, item: TextContentItem): boolean {
+    const previous = div.dataset[ALIGNED];
+    if (previous === undefined) return false;
+
+    div.style.fontFamily = previous;
+    const transform = div.dataset[ORIGINAL_TRANSFORM];
+    if (transform) div.style.transform = transform;
+    else div.style.removeProperty('transform');
+
+    // Earlier versions of this rewrote the node's children and gave it a width; undo that too, so
+    // that a build carrying leftovers from one of them still ends up with what PDF.js made.
+    if (div.childElementCount) div.replaceChildren(item.str);
+    div.style.removeProperty('width');
+
+    delete div.dataset[ALIGNED];
+    delete div.dataset[ORIGINAL_TRANSFORM];
+    return true;
+}
+
+
+/** Align (or revert) every text layer node of a page. Returns the number of nodes changed. */
+export function alignTextLayer(pageView: PDFPageView, align: boolean): number {
+    const info = pageView.textLayer && getTextLayerInfo(pageView.textLayer);
+    if (!info) return 0;
+
+    const { textDivs, textContentItems } = info;
+    let changed = 0;
+    for (let i = 0; i < textDivs.length && i < textContentItems.length; i++) {
+        const div = textDivs[i];
+        const item = textContentItems[i];
+        if (!div || !item) continue;
+        if (align ? alignTextLayerNode(div, item) : revertTextLayerNode(div, item)) changed++;
+    }
+    return changed;
+}


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.

---

### Description

**Related: #504.** The text layer is laid out with a generic family (`getTextContent` reports `styles[fontName].fontFamily` as `font.fallbackName`) and only each item's total width is corrected, with `scaleX`. That pins the ends of a line fragment and lets everything between them drift — 5.72pt on a page of a Nature paper, about a character and a half, so dragging across `74.1%` selects `4.1%)`.

PDF.js already installs each embedded font as an `@font-face` rule named after its loaded name, which is what a text item reports as its `fontName`. Naming that family on the node lays the text out in the metrics the page was set in, and leaves the layer otherwise untouched. Mean drift 1.24pt → 0.21pt, mis-hitting characters 2093 → 32 of 8131, no elements added, 1–3ms per page.

Not every font can be used this way, so which font to use is measured rather than assumed — details below. **Off by default.** Two commits; the second is a debug command that produced every figure here and can be dropped.

<details>
<summary>Full report: what it is, why this approach, what was tried instead, and testing</summary>

Dragging across `74.1%` in a Nature paper selects `4.1%)`. The link that gets copied is self-consistent — `{{text}}` and the `selection=` indices agree — it just quotes text the pointer was never over.

## Why

The text layer is laid out with a generic family. In the worker, `getTextContent` reports the style as the font's *fallback* name:

```js
y.styles[t] = { fontFamily: e.fallbackName, ascent: e.ascent, descent: e.descent, vertical: e.vertical };
```

so a page set in Harding Text is measured in whatever `serif` resolves to. `TextLayer.#layout` then corrects only the *total* width of each item:

```js
_ensureCtxFont.call(wa, a, o * scale, fontFamily);
const { width } = a.measureText(e.textContent);
width > 0 && (r = `scaleX(${canvasWidth * scale / width}) ${r}`);
```

That pins the two ends of a line fragment and lets everything between them drift. On page 2 of [Guan et al. 2025](https://doi.org/10.1038/s41588-025-02223-0) the drift reaches **5.72pt** — about a character and a half at 8.3pt — and **2093 of the page's 8131 characters** hit-test as a different character than the one drawn at that point.

Modelling the same line offline confirms where it comes from. Taking the item `'alternative splicings and 8,798 (74.1%) APAs (Fig. '` (51 characters, 187.80pt wide) and laying it out with each font's own advances:

| metrics used | scaleX | drift at `7` | dragging over painted `74.1%` selects |
|---|---|---|---|
| Times (what `serif` resolves to) | 1.0910 | −6.7pt ≈ 1.5 characters | **`4.1%)`** |
| the PDF's embedded HardingText-Regular | 1.0186 | ≤0.65pt | `74.1%` |

## What this does

The embedded fonts are not missing. `createFontFaceRule` installs each one as `@font-face { font-family: "<loadedName>"; src: url(data:...) }`, and a text item reports that same loaded name as its `fontName`. Naming that family on the node lays the text out in the metrics the page was set in.

Everything else about the layer is left alone — one span, one text node, one line box. The stretch PDF.js computed against the generic family is restated in the same proportion; PDF.js recomputes it the same way on its next relayout, reading the family from the node.

## Why not place the text directly

`item.chars` (Obsidian passes `includeChars: true`) gives a box per character, so the text can be placed exactly. I tried it two ways before this, and both are worth recording because the failure is not obvious:

- **Per-word, then per-run absolutely positioned spans.** Measured beautifully — worst drift 5.72pt → 0.56pt, mis-hits 2111 → 25 — and dragging became noticeably worse. `.textLayer span { position: absolute }` is a *descendant* selector, so anything added inside a node is out of flow whether or not you ask for it, and there is no line box for the browser to walk when it turns a dragged pointer into a text position. Measuring a character's box and asking which character a point belongs to are different questions; only the first one had been measured.
- **Runs kept in flow**, stretched with `letter-spacing` and `margin-right`. Worse still: in flow you can only control advances, so every prediction error accumulates along the line, and the item's content width — which PDF.js's `scaleX` was computed against — moves with it.

Turning the option off made a hard drag instantly smooth again in both cases, which is what pointed at the layer rather than at anything it had been measured against.

## The guard

A PDF.js font file is built to be drawn with rather than to lay text out with: glyphs are looked up under codepoints of its own choosing, so a font whose character map was synthesised from the PDF's encoding need not answer to the Unicode the text layer holds. Naming one of those made an Elsevier paper *worse* than it started — spaces and digits came out with zero advance, and the layer drifted 10pt where it had drifted 9pt.

So which font to use is measured, not assumed. For each font, the character widths it gives the item's text are compared against the widths the PDF gives the same characters, after the single scale factor that best relates the two — that freedom being exactly what the stretch already has. What is left is what no stretch can absorb. The PDF's font is used only where its disagreement stays under half a point *and* beats the generic family's. Decided once per font.

## Results

Page 2 of each paper, Obsidian 1.13.7, measured by the command in the second commit:

| | Guan 2025 (Nature) off → on | Du 2024 (Elsevier) off → on |
|---|---|---|
| mean drift | 1.24pt → **0.21pt** | 1.06pt → 1.05pt |
| worst drift | 5.72pt → **1.73pt** | 9.26pt → 9.26pt |
| characters hit-testing as another character | 2093 → **32** (of 8131) | 1709 → 1664 (of 8236) |
| fonts taken | most | 2 nodes of 264 |
| elements in the text layer | 235 → 235 | 264 → 264 |
| time per page | — | 1–3ms |

The Elsevier paper is the guard working: nearly every font is rejected and the page is left as PDF.js made it.

Every PDF in the library I tested against (33 papers) embeds all of its fonts, so the interesting failure is not a missing font but a font that cannot be laid out with — which is why the guard is a width comparison rather than an availability check. `document.fonts.check()` is no use here: an unknown family resolves to a fallback, the fallback is loaded, and the answer is yes for every name.

## Limitations

- The spacing a PDF puts between individual glyphs to justify a line is in the content stream, not in any font, so no choice of font reaches it. That is what the residual 1.73pt is.
- Fonts whose character maps do not answer to the text layer's characters are left alone, so some documents gain nothing.
- A font is judged on the first item long enough to judge it on (8 characters); items whose font has not been decided yet keep PDF.js's layout.
- After the swap PDF.js recomputes the node's `top` from the new font's ascent on its next relayout, so the layer can shift vertically by a fraction of a line. It is transparent, and PDF++ draws its own highlights from `item.chars`.

Off by default.

## Testing

Obsidian 1.13.7 / installer 1.12.4, macOS. Two papers with different typesetting, measured with the option off and on in the same run, plus dragging by hand on both — including the `8,798 (74.1%) APAs` line that started this, which now selects what it is pointed at.

The second commit is separable; nothing in the feature imports it. Happy to drop it if a debug command in the palette is unwelcome. It earned its place while this was being written: two earlier versions of the feature were silently doing nothing at all, and from the outside looked exactly like a version that worked but did not help much.

Related: #504.

</details>
