### PR TITLE
Fix editing page labels

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -899,8 +899,17 @@ export default class PDFPlus extends Plugin {
 	}
 
 	requireModKeyForLinkHover(id = 'pdf-plus') {
-		// @ts-ignore
-		return this.app.internalPlugins.plugins['page-preview'].instance.overrides[id]
+		// Obsidian 1.13 renamed the page-preview plugin's per-source override record
+		// from `overrides` to `options`. Reading the old name threw a TypeError, which,
+		// because `PDFPlusSettingTab.display` is async and Obsidian does not await it,
+		// silently aborted the rendering of the settings tab halfway through.
+		// https://github.com/RyotaUshio/obsidian-pdf-plus/issues/569
+		// The page-preview plugin can also be disabled altogether, in which case there is
+		// no instance to read from, so fall back to the source's default in that case too.
+		const instance = this.app.internalPlugins.plugins['page-preview'].instance;
+		const overrides = instance?.options ?? instance?.overrides;
+
+		return overrides?.[id]
 			?? this.app.workspace.hoverLinkSources[id]?.defaultMod
 			?? false;
 	}

--- a/src/modals/page-label-modals.ts
+++ b/src/modals/page-label-modals.ts
@@ -15,21 +15,21 @@ import { getModifierNameInPlatform } from 'utils';
 
 abstract class PDFPageLabelModal extends PDFPlusModal {
     controlEl: HTMLElement;
-    doc: PDFDocument | null;
+    pdf: PDFDocument | null;
     pageLabels: PDFPageLabels | null;
-    docLoadingPromise: Promise<{ doc: PDFDocument, pageLabels: PDFPageLabels | null }>;
+    pdfLoadingPromise: Promise<{ pdf: PDFDocument, pageLabels: PDFPageLabels | null }>;
 
     constructor(plugin: PDFPlus, public file: TFile) {
         super(plugin);
         this.containerEl.addClass('pdf-plus-page-label-modal');
         this.controlEl = this.contentEl.createDiv();
-        this.doc = null;
+        this.pdf = null;
         this.pageLabels = null;
-        this.docLoadingPromise = (async () => {
-            this.doc = await plugin.lib.loadPdfLibDocument(file);
-            this.pageLabels = PDFPageLabels.fromDocument(this.doc);
+        this.pdfLoadingPromise = (async () => {
+            this.pdf = await plugin.lib.loadPdfLibDocument(file);
+            this.pageLabels = PDFPageLabels.fromDocument(this.pdf);
 
-            return { doc: this.doc, pageLabels: this.pageLabels };
+            return { pdf: this.pdf, pageLabels: this.pageLabels };
         })();
 
         this.scope.register([], 'Enter', () => this.redisplay());
@@ -127,7 +127,7 @@ export class PDFPageLabelEditModal extends PDFPageLabelModal {
             text: 'Loading...'
         });
 
-        await this.docLoadingPromise;
+        await this.pdfLoadingPromise;
 
         this.display();
         this.addButtons();
@@ -139,8 +139,8 @@ export class PDFPageLabelEditModal extends PDFPageLabelModal {
     }
 
     display() {
-        const { pageLabels, doc } = this;
-        if (!doc) return;
+        const { pageLabels, pdf } = this;
+        if (!pdf) return;
 
         this.controlEl.empty();
 
@@ -152,7 +152,7 @@ export class PDFPageLabelEditModal extends PDFPageLabelModal {
                         .setButtonText('Create')
                         .setCta()
                         .onClick(() => {
-                            this.pageLabels = PDFPageLabels.createEmpty(doc);
+                            this.pageLabels = PDFPageLabels.createEmpty(pdf);
                             this.redisplay();
                             this.updateButtonVisibility();
                         });
@@ -166,7 +166,7 @@ export class PDFPageLabelEditModal extends PDFPageLabelModal {
             return;
         }
 
-        const pageCount = doc.getPageCount();
+        const pageCount = pdf.getPageCount();
 
         for (let i = 0; i < pageLabels.ranges.length; i++) {
             const rangeEl = this.controlEl.createDiv('page-label-range');
@@ -291,11 +291,11 @@ export class PDFPageLabelEditModal extends PDFPageLabelModal {
                         .setButtonText('Save')
                         .setCta()
                         .onClick(async () => {
-                            if (this.pageLabels && this.doc) {
+                            if (this.pageLabels && this.pdf) {
                                 if (this.pageLabels.rangeCount() > 0) {
-                                    this.pageLabels.setToDocument(this.doc);
-                                } else PDFPageLabels.removeFromDocument(this.doc);
-                                await this.app.vault.modifyBinary(this.file, await this.doc.save());
+                                    this.pageLabels.setToDocument(this.pdf);
+                                } else PDFPageLabels.removeFromDocument(this.pdf);
+                                await this.app.vault.modifyBinary(this.file, await this.pdf.save());
                             } else {
                                 new Notice(`${this.plugin.manifest.name}: Something went wrong.`);
                             }

--- a/src/patchers/page-preview.ts
+++ b/src/patchers/page-preview.ts
@@ -8,6 +8,8 @@ export const patchPagePreview = (plugin: PDFPlus): boolean => {
     const app = plugin.app;
     const lib = plugin.lib;
     const pagePreviewInstance = app.internalPlugins.plugins['page-preview'].instance;
+    // The Page preview core plugin can be turned off, in which case there is nothing to patch.
+    if (!pagePreviewInstance) return false;
 
     // Patch the instance instead of the prototype to avoid conflicts with Hover Editor
     // https://github.com/nothingislost/obsidian-hover-editor/issues/259

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1120,7 +1120,14 @@ declare module 'obsidian' {
                 'page-preview': {
                     instance: {
                         onLinkHover(hoverParent: HoverParent, targetEl: HTMLElement | null, linktext: string, sourcePath: string, state: any): void;
-                    }
+                        /**
+                         * Per-hover-link-source overrides of "require Mod key to trigger the preview".
+                         * Named `options` in Obsidian 1.13 and later, `overrides` before that.
+                         */
+                        options?: Record<string, boolean | undefined>;
+                        /** @deprecated Renamed to {@link options} in Obsidian 1.13. */
+                        overrides?: Record<string, boolean | undefined>;
+                    } | undefined
                     enabled: boolean;
                     enable(): void;
                     disable(): void;

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1334,4 +1334,9 @@ declare module 'obsidian' {
     interface KeymapEventHandler {
         func: KeymapEventListener;
     }
+
+    interface Modal {
+        /* Introduced in Obsidian 1.13 most likely */
+        readonly doc: Document;
+    }
 }


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines.

---

### Description

Fixes #576 by renaming `PDFPageLabelModal`'s `doc` field to `pdf`.

For consistency, also renames `docLoadingPromise` to `pdfLoadingPromise`, and its `doc` field to `pdf`.

Includes #572 so the whole modal is rendered. Without it, rendering throws partway through.

<details>

<summary>Why these fixes?</summary>

At some point (1.13 perhaps?), Obsidian's `Modal` class, which `PDFPageLabelModal` extends, had a get-only `doc` property added to it.  
This caused `PDFPageLabelModal` attempting to set its `doc` field throw an error.  
This was easily fixed by renaming the field to something else.  
I also added `Modal`s readonly `doc` property to typings to prevent future regressions.

Additionally, just like settings, the modal stops rendering as soon as `requireModKeyForLinkHover` is called, which happens inside `addPreviewButton`.  
`requireModKeyForLinkHover` is already fixed by #572, so I've included that PR in this one. Credits to @mintmilk for that obviously.

</details>
